### PR TITLE
ENVELOPE should use the RFC1123Z time format.

### DIFF
--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/client"
@@ -109,7 +110,7 @@ func TestClient_Search(t *testing.T) {
 	ct := func(c *client.Client) (err error) {
 		c.State = imap.SelectedState
 
-		date, _ := imap.ParseDate("1-Feb-1994")
+		date, _ := time.Parse(imap.DateFormat, "1-Feb-1994")
 		criteria := &imap.SearchCriteria{
 			Deleted: true,
 			From:    "Smith",

--- a/commands/append.go
+++ b/commands/append.go
@@ -86,7 +86,7 @@ func (cmd *Append) Parse(fields []interface{}) (err error) {
 			if !ok {
 				return errors.New("Date must be a string")
 			}
-			if cmd.Date, err = imap.ParseDateTime(date); err != nil {
+			if cmd.Date, err = time.Parse(imap.DateTimeFormat, date); err != nil {
 				return err
 			}
 		}

--- a/message.go
+++ b/message.go
@@ -61,6 +61,22 @@ const (
 	MimeSpecifier = "MIME"
 )
 
+// Date and time formats used as examples in RFC 3501 section 8.
+const (
+	// The date format described in RFC 2822 section 3.3.
+	EnvelopeDateTimeFormat = "Mon, 02 Jan 2006 15:04:05 -0700"
+	// Described in RFC 1730 on page 55.
+	DateFormat = "2-Jan-2006"
+	// Described in RFC 1730 on page 55.
+	DateTimeFormat = "2-Jan-2006 15:04:05 -0700"
+)
+
+// A time.Time with a specific layout
+type timeLayout struct {
+	date   time.Time
+	layout string
+}
+
 // Returns the canonical form of a flag. Flags are case-insensitive.
 //
 // If the flag is defined in RFC 3501, it returns the flag with the case of the
@@ -90,7 +106,7 @@ type Message struct {
 	BodyStructure *BodyStructure
 	// The message flags.
 	Flags []string
-	// The date the message was received by th server.
+	// The date the message was received by the server.
 	InternalDate time.Time
 	// The message size.
 	Size uint32
@@ -152,7 +168,7 @@ func (m *Message) Parse(fields []interface{}) error {
 				}
 			case InternalDateMsgAttr:
 				date, _ := f.(string)
-				m.InternalDate, _ = ParseDateTime(date)
+				m.InternalDate, _ = time.Parse(DateTimeFormat, date)
 			case SizeMsgAttr:
 				m.Size, _ = ParseNumber(f)
 			case UidMsgAttr:
@@ -520,7 +536,7 @@ func (e *Envelope) Parse(fields []interface{}) error {
 	}
 
 	if date, ok := fields[0].(string); ok {
-		e.Date, _ = ParseDateTime(date)
+		e.Date, _ = time.Parse(EnvelopeDateTimeFormat, date)
 	}
 	if subject, ok := fields[1].(string); ok {
 		e.Subject = subject
@@ -556,7 +572,7 @@ func (e *Envelope) Parse(fields []interface{}) error {
 // Format an envelope to fields.
 func (e *Envelope) Format() (fields []interface{}) {
 	return []interface{}{
-		e.Date,
+		&timeLayout{date: e.Date, layout: EnvelopeDateTimeFormat},
 		e.Subject,
 		FormatAddressList(e.From),
 		FormatAddressList(e.Sender),

--- a/message_test.go
+++ b/message_test.go
@@ -29,28 +29,6 @@ func formatFields(fields []interface{}) (string, error) {
 	return b.String(), nil
 }
 
-func TestParseDate(t *testing.T) {
-	tests := []struct {
-		dateStr string
-		exp     time.Time
-	}{
-		{
-			"21-Nov-1997 09:55:06 -0600",
-			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
-		},
-	}
-	for _, test := range tests {
-		date, err := ParseDateTime(test.dateStr)
-		if err != nil {
-			t.Errorf("Failed parsing %q: %v", test.dateStr, err)
-			continue
-		}
-		if !date.Equal(test.exp) {
-			t.Errorf("Parse of %q: got %+v, want %+v", test.dateStr, date, test.exp)
-		}
-	}
-}
-
 var messageTests = []struct {
 	message *Message
 	fields  []interface{}
@@ -270,7 +248,7 @@ var envelopeTests = []struct {
 			MessageId: "43@example.org",
 		},
 		fields: []interface{}{
-			"10-Nov-2009 23:00:00 -0600",
+			"Tue, 10 Nov 2009 23:00:00 -0600",
 			"Hello World!",
 			[]interface{}{addrTests[0].fields},
 			[]interface{}{},

--- a/read.go
+++ b/read.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"time"
 )
 
 const (
@@ -75,26 +74,6 @@ func ParseNumber(f interface{}) (uint32, error) {
 	}
 
 	return uint32(nbr), nil
-}
-
-func ParseDate(f interface{}) (t time.Time, err error) {
-	s, ok := f.(string)
-	if !ok {
-		err = newParseError("imap: date is not a string")
-		return
-	}
-
-	return time.Parse("2-Jan-2006", s)
-}
-
-func ParseDateTime(f interface{}) (t time.Time, err error) {
-	s, ok := f.(string)
-	if !ok {
-		err = newParseError("imap: date-time is not a string")
-		return
-	}
-
-	return time.Parse("2-Jan-2006 15:04:05 -0700", s)
 }
 
 // Convert a field list to a string list.

--- a/search.go
+++ b/search.go
@@ -68,7 +68,7 @@ func (c *SearchCriteria) Parse(fields []interface{}) error {
 			c.Bcc, _ = fields[i].(string)
 		case "BEFORE":
 			i++
-			c.Before, _ = ParseDate(fields[i])
+			c.Before, _ = time.Parse(DateFormat, fields[i].(string))
 		case "BODY":
 			i++
 			c.Body, _ = fields[i].(string)
@@ -111,7 +111,7 @@ func (c *SearchCriteria) Parse(fields []interface{}) error {
 			c.Old = true
 		case "ON":
 			i++
-			c.On, _ = ParseDate(fields[i])
+			c.On, _ = time.Parse(DateFormat, fields[i].(string))
 		case "OR":
 			i++
 			leftFields, _ := fields[i].([]interface{})
@@ -132,19 +132,19 @@ func (c *SearchCriteria) Parse(fields []interface{}) error {
 			c.Seen = true
 		case "SENTBEFORE":
 			i++
-			c.SentBefore, _ = ParseDate(fields[i])
+			c.SentBefore, _ = time.Parse(DateFormat, fields[i].(string))
 		case "SENTON":
 			i++
-			c.SentOn, _ = ParseDate(fields[i])
+			c.SentOn, _ = time.Parse(DateFormat, fields[i].(string))
 		case "SENTSINCE":
 			i++
-			c.SentSince, _ = ParseDate(fields[i])
+			c.SentSince, _ = time.Parse(DateFormat, fields[i].(string))
 		case "SINCE":
 			i++
-			c.Since, _ = ParseDate(fields[i])
+			c.Since, _ = time.Parse(DateFormat, fields[i].(string))
 		case "SMALLER":
 			i++
-			c.Smaller, _ = ParseNumber(fields[i])
+			c.Smaller, _ = ParseNumber(fields[i].(string))
 		case "SUBJECT":
 			i++
 			c.Subject, _ = fields[i].(string)
@@ -196,7 +196,7 @@ func (c *SearchCriteria) Format() (fields []interface{}) {
 		fields = append(fields, "BCC", c.Bcc)
 	}
 	if !c.Before.IsZero() {
-		fields = append(fields, "BEFORE", FormatDate(c.Before))
+		fields = append(fields, "BEFORE", c.Before.Format(DateFormat))
 	}
 	if c.Body != "" {
 		fields = append(fields, "BODY", c.Body)
@@ -235,7 +235,7 @@ func (c *SearchCriteria) Format() (fields []interface{}) {
 		fields = append(fields, "OLD")
 	}
 	if !c.On.IsZero() {
-		fields = append(fields, "ON", FormatDate(c.On))
+		fields = append(fields, "ON", c.On.Format(DateFormat))
 	}
 	if c.Or[0] != nil && c.Or[1] != nil {
 		fields = append(fields, "OR", c.Or[0].Format(), c.Or[1].Format())
@@ -247,16 +247,16 @@ func (c *SearchCriteria) Format() (fields []interface{}) {
 		fields = append(fields, "SEEN")
 	}
 	if !c.SentBefore.IsZero() {
-		fields = append(fields, "SENTBEFORE", FormatDate(c.SentBefore))
+		fields = append(fields, "SENTBEFORE", c.SentBefore.Format(DateFormat))
 	}
 	if !c.SentOn.IsZero() {
-		fields = append(fields, "SENTON", FormatDate(c.SentOn))
+		fields = append(fields, "SENTON", c.SentOn.Format(DateFormat))
 	}
 	if !c.SentSince.IsZero() {
-		fields = append(fields, "SENTSINCE", FormatDate(c.SentSince))
+		fields = append(fields, "SENTSINCE", c.SentSince.Format(DateFormat))
 	}
 	if !c.Since.IsZero() {
-		fields = append(fields, "SINCE", FormatDate(c.Since))
+		fields = append(fields, "SINCE", c.Since.Format(DateFormat))
 	}
 	if c.Smaller != 0 {
 		fields = append(fields, "SMALLER", c.Smaller)

--- a/write.go
+++ b/write.go
@@ -24,14 +24,6 @@ func formatNumber(num uint32) string {
 	return strconv.FormatUint(uint64(num), 10)
 }
 
-func FormatDate(t time.Time) string {
-	return t.Format("2-Jan-2006")
-}
-
-func FormatDateTime(t time.Time) string {
-	return t.Format("2-Jan-2006 15:04:05 -0700")
-}
-
 // Convert a string list to a field list.
 func FormatStringList(list []string) (fields []interface{}) {
 	fields = make([]interface{}, len(list))
@@ -98,11 +90,11 @@ func (w *Writer) writeAstring(s string) error {
 	return w.writeAtom(s)
 }
 
-func (w *Writer) writeDateTime(t time.Time) error {
+func (w *Writer) writeDateTime(t time.Time, layout string) error {
 	if t.IsZero() {
 		return w.writeAtom(nilAtom)
 	}
-	return w.writeQuoted(FormatDateTime(t))
+	return w.writeQuoted(t.Format(layout))
 }
 
 func (w *Writer) writeFields(fields []interface{}) error {
@@ -177,8 +169,10 @@ func (w *Writer) writeField(field interface{}) error {
 		return w.writeLiteral(field)
 	case []interface{}:
 		return w.writeList(field)
+	case *timeLayout:
+		return w.writeDateTime(field.date, field.layout)
 	case time.Time:
-		return w.writeDateTime(field)
+		return w.writeDateTime(field, DateTimeFormat)
 	case *SeqSet:
 		return w.writeString(field.String())
 	case *BodySectionName:


### PR DESCRIPTION
RFC 3501 uses this format in its sample connection:

  https://tools.ietf.org/html/rfc3501#section-8

Seems like this format is inspired by RFC2822's specification:

  https://tools.ietf.org/html/rfc2822#section-3.3

FastMail and Gmail also the RFC1123Z format for ENVELOPE.