### PR TITLE
Use a sync.Mutex to protect writes on mbox Items

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -286,7 +286,9 @@ func (c *Client) handleUnilateral() {
 
 				if messages, err := imap.ParseNumber(res.Fields[0]); err == nil {
 					c.Mailbox.Messages = messages
+					c.Mailbox.ItemsLocker.Lock()
 					c.Mailbox.Items[imap.MailboxMessages] = nil
+					c.Mailbox.ItemsLocker.Unlock()
 				}
 
 				if c.MailboxUpdates != nil {
@@ -299,7 +301,9 @@ func (c *Client) handleUnilateral() {
 
 				if recent, err := imap.ParseNumber(res.Fields[0]); err == nil {
 					c.Mailbox.Recent = recent
+					c.Mailbox.ItemsLocker.Lock()
 					c.Mailbox.Items[imap.MailboxRecent] = nil
+					c.Mailbox.ItemsLocker.Unlock()
 				}
 
 				if c.MailboxUpdates != nil {

--- a/mailbox.go
+++ b/mailbox.go
@@ -3,6 +3,7 @@ package imap
 import (
 	"errors"
 	"strings"
+	"sync"
 
 	"github.com/emersion/go-imap/utf7"
 )
@@ -147,6 +148,10 @@ type MailboxStatus struct {
 	// should not be used directly, they must only be used by libraries
 	// implementing extensions of the IMAP protocol.
 	Items map[string]interface{}
+
+	// The Items map may be accessed in different goroutines. Protect
+	// concurrent writes.
+	ItemsLocker sync.Mutex
 
 	// The mailbox flags.
 	Flags []string

--- a/responses/select.go
+++ b/responses/select.go
@@ -37,17 +37,25 @@ func (r *Select) HandleFrom(hdlr imap.RespHandler) (err error) {
 			switch res.Code {
 			case imap.MailboxUnseen:
 				mbox.Unseen, _ = imap.ParseNumber(res.Arguments[0])
+				mbox.ItemsLocker.Lock()
 				mbox.Items[imap.MailboxUnseen] = nil
+				mbox.ItemsLocker.Unlock()
 			case imap.MailboxPermanentFlags:
 				flags, _ := res.Arguments[0].([]interface{})
 				mbox.PermanentFlags, _ = imap.ParseStringList(flags)
+				mbox.ItemsLocker.Lock()
 				mbox.Items[imap.MailboxPermanentFlags] = nil
+				mbox.ItemsLocker.Unlock()
 			case imap.MailboxUidNext:
 				mbox.UidNext, _ = imap.ParseNumber(res.Arguments[0])
+				mbox.ItemsLocker.Lock()
 				mbox.Items[imap.MailboxUidNext] = nil
+				mbox.ItemsLocker.Unlock()
 			case imap.MailboxUidValidity:
 				mbox.UidValidity, _ = imap.ParseNumber(res.Arguments[0])
+				mbox.ItemsLocker.Lock()
 				mbox.Items[imap.MailboxUidValidity] = nil
+				mbox.ItemsLocker.Unlock()
 			default:
 				accepted = false
 			}


### PR DESCRIPTION
This is intended to correct potential concurrent map write errors.

I have a small program that I run in cron to monitor a mailbox. I found it crashed once. Here is the output from the crash:

`
fatal error: concurrent map writes

goroutine 24 [running]:
runtime.throw(0x8350ff0, 0x15)
	/home/will/bin/go-src/src/runtime/panic.go:547 +0x7f fp=0x18718e78 sp=0x18718e6c
runtime.mapassign1(0x82978e0, 0x1875f300, 0x18718f3c, 0x18718f34)
	/home/will/bin/go-src/src/runtime/hashmap.go:445 +0x8b fp=0x18718ed8 sp=0x18718e78
github.com/emersion/go-imap/responses.(*Select).HandleFrom(0x18764768, 0x18761280, 0x0, 0x0)
	/home/will/code/go/src/github.com/emersion/go-imap/responses/select.go:47 +0x3af fp=0x18718fb4 sp=0x18718ed8
github.com/emersion/go-imap/client.(*Client).execute.func2(0x187612c0, 0xb5b2d910, 0x18764768, 0x18764788)
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:125 +0x2f fp=0x18718fd0 sp=0x18718fb4
runtime.goexit()
	/home/will/bin/go-src/src/runtime/asm_386.s:1585 +0x1 fp=0x18718fd4 sp=0x18718fd0
created by github.com/emersion/go-imap/client.(*Client).execute
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:131 +0x1d3

goroutine 1 [select]:
github.com/emersion/go-imap/client.(*Client).execute(0x18a0ce60, 0xb5b2d8f8, 0x18767480, 0xb5b2d910, 0x18764768, 0x0, 0x0, 0x0)
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:135 +0x45a
github.com/emersion/go-imap/client.(*Client).Select(0x18a0ce60, 0xbffb2f50, 0xc, 0x18762201, 0x187611c0, 0x0, 0x0)
	/home/will/code/go/src/github.com/emersion/go-imap/client/cmd_auth.go:36 +0x1ce
main.fetchMessages(0xbffb2eea, 0xe, 0x3e1, 0xbffb2eff, 0x11, 0x18762240, 0x28, 0xbffb2f50, 0xc, 0x1875e000, ...)
	/home/will/code/go/src/summercat.com/imap-notify/imap-notify.go:216 +0x561
main.main()
	/home/will/code/go/src/summercat.com/imap-notify/imap-notify.go:83 +0x2e3

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/home/will/bin/go-src/src/runtime/asm_386.s:1585 +0x1

goroutine 34 [chan receive]:
github.com/emersion/go-imap/client.(*Client).handleContinuationReqs(0x18a0ce60, 0x18a0ae40)
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:185 +0xd3
created by github.com/emersion/go-imap/client.New
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:385 +0x3ae

goroutine 35 [runnable]:
github.com/emersion/go-imap/client.(*Client).handleUnilateral(0x18a0ce60)
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:214 +0x120
created by github.com/emersion/go-imap/client.New
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:386 +0x3ce

goroutine 36 [chan receive]:
github.com/emersion/go-imap.(*MultiRespHandler).HandleFrom(0x18a1b960, 0x18a0ae80, 0x0, 0x0)
	/home/will/code/go/src/github.com/emersion/go-imap/handle.go:78 +0x19a
created by github.com/emersion/go-imap/client.New
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:387 +0x3f8

goroutine 37 [chan receive]:
github.com/emersion/go-imap/client.(*Client).read(0x18a0ce60, 0x18a0b000, 0x0, 0x0)
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:95 +0x3a0
created by github.com/emersion/go-imap/client.(*Client).handleUnilateral
	/home/will/code/go/src/github.com/emersion/go-imap/client/client.go:212 +0xf4
`

The portion of my program (https://github.com/horgh/imap-notify) that was in progress at the time:

`
	client, err := client.DialTLS(fmt.Sprintf("%s:%d", host, port), nil)
	if err != nil {
		return nil, fmt.Errorf("Unable to connect to IMAP server: %s", err)
	}

	defer client.Logout()

	err = client.Login(user, pass)
	if err != nil {
		return nil, fmt.Errorf("Unable to login to IMAP: %s", err)
	}

	mbox, err := client.Select(mailbox, true)
	if err != nil {
		return nil, fmt.Errorf("Unable to select mailbox: %s: %s", mailbox, err)
	}
`

This happened during `Select()`.

After looking at your library, I believe the problem is the changes to the mailbox Items map in client.go's `handleUnilateral()` as well as in select.go's `HandleFrom()`.

I believe what happened was a new message arrived during my SELECT command's response. I'm not sure though. I can't reproduce it.

To try to resolve this, in my commit I protect changes to the map with a `sync.Mutex`. This is a bit verbose and ugly.

Please let me know if I can provide any more information or if you would like me to change anything.

Thank you for creating this library by the way, it's very useful, and was very easy to use!