### PR TITLE
Add client Dial functions with net.Dialer parameters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// An IMAP client.
+// Package client provides an IMAP client.
 package client
 
 import (
@@ -11,7 +11,7 @@ import (
 	"github.com/emersion/go-imap"
 )
 
-// An IMAP client.
+// Client represents an IMAP client.
 type Client struct {
 	conn  *imap.Conn
 	isTLS bool
@@ -343,7 +343,7 @@ func (c *Client) Upgrade(upgrader imap.ConnUpgrader) error {
 	return c.conn.Upgrade(upgrader)
 }
 
-// Get an imap.Writer for this client's connection.
+// Writer returns the imap.Writer for this client's connection.
 //
 // This function should not be called directly, it must only be used by
 // libraries implementing extensions of the IMAP protocol.
@@ -351,7 +351,7 @@ func (c *Client) Writer() *imap.Writer {
 	return c.conn.Writer
 }
 
-// Check if this client's connection has TLS enabled.
+// IsTLS checks if this client's connection has TLS enabled.
 func (c *Client) IsTLS() bool {
 	return c.isTLS
 }
@@ -392,7 +392,7 @@ func New(conn net.Conn) (c *Client, err error) {
 	return
 }
 
-// Connect to an IMAP server using an unencrypted connection.
+// Dial connects to an IMAP server using an unencrypted connection.
 func Dial(addr string) (c *Client, err error) {
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
@@ -417,7 +417,7 @@ func DialWithDialer(dialer *net.Dialer, address string) (c *Client, err error) {
 	return
 }
 
-// Connect to an IMAP server using an encrypted connection.
+// DialTLS connects to an IMAP server using an encrypted connection.
 func DialTLS(addr string, tlsConfig *tls.Config) (c *Client, err error) {
 	conn, err := tls.Dial("tcp", addr, tlsConfig)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,9 @@ import (
 	"github.com/emersion/go-imap"
 )
 
+// Used when a connection is closed while waiting for a command response.
+var errClosed = fmt.Errorf("imap: connection closed")
+
 // Client represents an IMAP client.
 type Client struct {
 	conn  *imap.Conn
@@ -162,7 +165,7 @@ func (c *Client) execute(cmdr imap.Commander, res imap.RespHandlerFrom) (status 
 		// this and don't block waiting on a response that will never come. loggedOut
 		// is a channel that closes when the reader goroutine ends.
 		case <-c.loggedOut:
-			err = fmt.Errorf("Connection closed")
+			err = errClosed
 			return
 		case err = <-written:
 			if err != nil {
@@ -195,10 +198,10 @@ func (c *Client) execute(cmdr imap.Commander, res imap.RespHandlerFrom) (status 
 	}
 }
 
-// Execute a generic command. cmdr is a value that can be converted to a raw
-// command and res is a value that can handle responses. The function returns
-// when the command has completed or failed, in this case err is nil. A non-nil
-// err value indicates a network error.
+// Execute executes a generic command. cmdr is a value that can be converted to
+// a raw command and res is a value that can handle responses. The function
+// returns when the command has completed or failed, in this case err is nil. A
+// non-nil err value indicates a network error.
 //
 // This function should not be called directly, it must only be used by
 // libraries implementing extensions of the IMAP protocol.

--- a/client/client.go
+++ b/client/client.go
@@ -368,6 +368,11 @@ func (c *Client) SetDebug(w io.Writer) {
 	c.conn.SetDebug(w)
 }
 
+// Conn returns the client's imap.Conn.
+func (c *Client) Conn() *imap.Conn {
+	return c.conn
+}
+
 // New creates a new client from an existing connection.
 func New(conn net.Conn) (c *Client, err error) {
 	continues := make(chan bool)

--- a/client/client.go
+++ b/client/client.go
@@ -403,9 +403,39 @@ func Dial(addr string) (c *Client, err error) {
 	return
 }
 
+// DialWithDialer connects to an IMAP server using an unencrypted connection
+// using dialer.Dial.
+//
+// Among other uses, this allows us to apply a connection timeout.
+func DialWithDialer(dialer *net.Dialer, address string) (c *Client, err error) {
+	conn, err := dialer.Dial("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err = New(conn)
+	return
+}
+
 // Connect to an IMAP server using an encrypted connection.
 func DialTLS(addr string, tlsConfig *tls.Config) (c *Client, err error) {
 	conn, err := tls.Dial("tcp", addr, tlsConfig)
+	if err != nil {
+		return
+	}
+
+	c, err = New(conn)
+	c.isTLS = true
+	return
+}
+
+// DialWithDialerTLS connects to an IMAP server using an encrypted connection
+// using dialer.Dial.
+//
+// Among other uses, this allows us to apply a connection timeout.
+func DialWithDialerTLS(dialer *net.Dialer, addr string,
+	tlsConfig *tls.Config) (c *Client, err error) {
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
 	if err != nil {
 		return
 	}

--- a/client/cmd_any.go
+++ b/client/cmd_any.go
@@ -53,21 +53,20 @@ func (c *Client) Noop() (err error) {
 }
 
 // Close the connection.
-func (c *Client) Logout() (err error) {
+func (c *Client) Logout() error {
 	if c.State == imap.LogoutState {
-		err = ErrAlreadyLoggedOut
-		return
+		return ErrAlreadyLoggedOut
 	}
 
 	cmd := &commands.Logout{}
 
-	status, err := c.execute(cmd, nil)
-	if err != nil {
-		return
+	if status, err := c.execute(cmd, nil); err == errClosed {
+		// Server closed connection, that's what we want anyway
+		return nil
+	} else if err != nil {
+		return err
+	} else if status != nil {
+		return status.Err()
 	}
-
-	if status != nil {
-		err = status.Err()
-	}
-	return
+	return nil
 }

--- a/client/cmd_any_test.go
+++ b/client/cmd_any_test.go
@@ -58,9 +58,8 @@ func TestClient_Noop(t *testing.T) {
 }
 
 func TestClient_Logout(t *testing.T) {
-	ct := func(c *client.Client) (err error) {
-		err = c.Logout()
-		return
+	ct := func(c *client.Client) error {
+		return c.Logout()
 	}
 
 	st := func(c net.Conn) {


### PR DESCRIPTION
In these changes I add two client Dialer functions that let us pass in a net.Dialer. Primarily I wanted to make it possible to add timeouts.

This is similar to the crypto/tls package's DialWithDialer function: https://godoc.org/crypto/tls#DialWithDialer

It is likely possible to do something similar using the already present client.New function, but I figure this is a little bit of a nicer interface.

I also expose a way to retrieve the underlying imap.Conn/net.Conn to the client. Again this is because I want to be able to add timeouts (or rather, set a deadline).

Why? Well, I have a small program that runs from cron to check an IMAP mailbox. I found that sometimes the program hangs seemingly forever. Today I have 9 stuck running for example.

If I strace one of them I see this:

```
# strace -p 29433
strace: Process 29433 attached
futex(0x8537004, FUTEX_WAIT, 0, NULL
```

Looking at its open files:

```
# lsof -p 29433
COMMAND     PID USER   FD      TYPE   DEVICE SIZE/OFF     NODE NAME
imap-noti 29433 will  cwd       DIR      8,1    16384  2754342 /home/will
imap-noti 29433 will  rtd       DIR      8,1     4096        2 /
imap-noti 29433 will  txt       REG      8,1  7199880 28705989 /tmp/go-build337774699/summercat.com/imap-notify/_obj/exe/imap-notify (deleted)
imap-noti 29433 will  DEL       REG      8,1          23855716 /lib/i386-linux-gnu/libc-2.24.so
imap-noti 29433 will  DEL       REG      8,1          23855828 /lib/i386-linux-gnu/libpthread-2.24.so
imap-noti 29433 will  DEL       REG      8,1          23855499 /lib/i386-linux-gnu/ld-2.24.so
imap-noti 29433 will    0r     FIFO     0,10      0t0 46312492 pipe
imap-noti 29433 will    1u      REG      8,1        0 28705046 /tmp/tmpf8qQXZw (deleted)
imap-noti 29433 will    2u      REG      8,1        0 28705046 /tmp/tmpf8qQXZw (deleted)
imap-noti 29433 will    3u     IPv4 46312510      0t0      TCP leviathan.summercat.com:58476->pc-in-f108.1e100.net:imaps (CLOSE_WAIT)
imap-noti 29433 will    5u  a_inode     0,11        0     1036 [eventpoll]
```

I believe having a timeout will solve this.

If you are interested, in this commit I make use of the functions here to add timeouts/deadlines to my program:

https://github.com/horgh/imap-notify/commit/87cb58f786454b733a4740c41892914fa9c7c83c

Please let me know if you see anything I should improve or that you'd like me to change.

Thanks for your time!