### PR TITLE
Simplify showcased client code

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,15 @@ func main() {
 
 	// List mailboxes
 	mailboxes := make(chan *imap.MailboxInfo)
-	done := make(chan error, 1)
 	go func () {
-		done <- c.List("", "*", mailboxes)
+		if err := c.List("", "*", mailboxes); err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	log.Println("Mailboxes:")
 	for m := range mailboxes {
 		log.Println("* " + m.Name)
-	}
-
-	if err := <-done; err != nil {
-		log.Fatal(err)
 	}
 
 	// Select INBOX

--- a/README.md
+++ b/README.md
@@ -115,18 +115,16 @@ func main() {
 	seqset, _ := imap.NewSeqSet("")
 	seqset.AddRange(mbox.Messages - 3, mbox.Messages)
 
-	messages := make(chan *imap.Message)
-	done = make(chan error, 1)
+	messages := make(chan *imap.Message, 10)
 	go func() {
-		done <- c.Fetch(seqset, []string{imap.EnvelopeMsgAttr}, messages)
+		// c.Fetch would close the messages channel when done.
+		if err := c.Fetch(seqset, []string{imap.EnvelopeMsgAttr}, messages); err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	for msg := range messages {
 		log.Println(msg.Envelope.Subject)
-	}
-
-	if err := <-done; err != nil {
-		log.Fatal(err)
 	}
 
 	log.Println("Done!")

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ func main() {
 	log.Println("Logged in")
 
 	// List mailboxes
-	mailboxes := make(chan *imap.MailboxInfo)
+	mailboxes := make(chan *imap.MailboxInfo, 10)
 	go func () {
 		if err := c.List("", "*", mailboxes); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Don't need the done channel because messages channel is being closed by the call to client.Fetch.