### PR TITLE
Use a mutex to protect access the client Caps map

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -28,11 +28,11 @@ type Client struct {
 	greeted   chan struct{}
 	loggedOut chan struct{}
 
-	// The Caps map may be accessed in different goroutines. Protect access.
+	// The cached server capabilities.
+	caps map[string]bool
+	// The caps map may be accessed in different goroutines. Protect access.
 	capsLocker sync.Mutex
 
-	// The server capabilities.
-	Caps map[string]bool
 	// The current connection state.
 	State imap.ConnState
 	// The selected mailbox, if there is one.
@@ -234,11 +234,10 @@ func (c *Client) handleContinuationReqs(continues chan<- bool) {
 func (c *Client) gotStatusCaps(args []interface{}) {
 	c.capsLocker.Lock()
 
-	c.Caps = make(map[string]bool)
-
+	c.caps = make(map[string]bool)
 	for _, cap := range args {
 		if cap, ok := cap.(string); ok {
-			c.Caps[cap] = true
+			c.caps[cap] = true
 		}
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -90,7 +90,9 @@ func removeCmdTag(cmd string) string {
 
 func TestClient(t *testing.T) {
 	ct := func(c *client.Client) error {
-		if !c.Caps["IMAP4rev1"] {
+		if ok, err := c.Support("IMAP4rev1"); err != nil {
+			return err
+		} else if !ok {
 			return errors.New("Server hasn't IMAP4rev1 capability")
 		}
 		return nil

--- a/client/cmd_any.go
+++ b/client/cmd_any.go
@@ -33,7 +33,10 @@ func (c *Client) Capability() (caps map[string]bool, err error) {
 		caps[name] = true
 	}
 
+	c.capsLocker.Lock()
 	c.Caps = caps
+	c.capsLocker.Unlock()
+
 	return
 }
 


### PR DESCRIPTION
Hi again!

This is to resolve a panic I encountered:


```
panic: assignment to entry in nil map

goroutine 37 [running]:
panic(0x8253380, 0x18768800)
        /home/will/bin/go-src/src/runtime/panic.go:500 +0x331
github.com/emersion/go-imap/client.(*Client).gotStatusCaps(0x189f8fa0, 0x18788798, 0x14, 0x15)
        /home/will/code/go/src/github.com/emersion/go-imap/client/client.go:234 +0x12c
github.com/emersion/go-imap/client.(*Client).handleUnilateral(0x189f8fa0)
        /home/will/code/go/src/github.com/emersion/go-imap/client/client.go:314 +0xbc5
created by github.com/emersion/go-imap/client.New
        /home/will/code/go/src/github.com/emersion/go-imap/client/client.go:435 +0x3c2
```

From what I can gather, there are at least two goroutines that will access this map. `handleUnilateral()`, and when using functions such as `Login()`.

Thanks for your time!