### PR TITLE
Fix login state checking condition

### DIFF
--- a/client/cmd_noauth.go
+++ b/client/cmd_noauth.go
@@ -115,7 +115,7 @@ func (c *Client) Authenticate(auth sasl.Client) error {
 // Login identifies the client to the server and carries the plaintext password
 // authenticating this user.
 func (c *Client) Login(username, password string) error {
-	if c.State() != imap.NotAuthenticatedState {
+	if state := c.State(); state == imap.AuthenticatedState || state == imap.SelectedState {
 		return ErrAlreadyLoggedIn
 	}
 


### PR DESCRIPTION
The current condition:

```
c.State() != imap.NotAuthenticatedState
```

give an confused message already login since when client state is `imap.LogoutState`. The client is already login only if it's in `imap.AuthenticatedState` or `imap.SelectedState`.