### PR TITLE
Client - FIXED: return err to chan, from c.read()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -454,7 +454,9 @@ func (c *Client) handleGreetAndStartReading() error {
 
 	// Make sure to start reading after we have set up this handler, otherwise
 	// some messages will be lost.
-	go c.read(greeted)
+	go func() {
+		done <- c.read(greeted)
+	}()
 
 	return <-done
 }

--- a/client/client.go
+++ b/client/client.go
@@ -417,7 +417,7 @@ func (c *Client) handleUnilateral() {
 }
 
 func (c *Client) handleGreetAndStartReading() error {
-	done := make(chan error, 1)
+	done := make(chan error, 2)
 	greeted := make(chan struct{})
 
 	c.registerHandler(responses.HandlerFunc(func(resp imap.Resp) error {


### PR DESCRIPTION
According to issue [#140](https://github.com/emersion/go-imap/issues/140)