### PR TITLE
backendutil: skip part header when using an index

### DIFF
--- a/backend/backendutil/body.go
+++ b/backend/backendutil/body.go
@@ -47,9 +47,16 @@ func FetchBodySection(e *message.Entity, section *imap.BodySectionName) (imap.Li
 	}
 	defer mw.Close()
 
-	// If the header hasn't been requested, discard it
-	if section.Specifier == imap.TextSpecifier {
+	switch section.Specifier {
+	case imap.TextSpecifier:
+		// The header hasn't been requested. Discard it.
 		b.Reset()
+	case imap.EntireSpecifier:
+		if len(section.Path) > 0 {
+			// When selecting a specific part by index, IMAP servers
+			// return only the text, not the associated MIME header.
+			b.Reset()
+		}
 	}
 
 	// Write the body, if requested

--- a/backend/backendutil/body_test.go
+++ b/backend/backendutil/body_test.go
@@ -19,11 +19,11 @@ var bodyTests = []struct {
 	},
 	{
 		section: "BODY[1]",
-		body:    testTextString,
+		body:    testTextBodyString,
 	},
 	{
 		section: "BODY[2]",
-		body:    testAttachmentString,
+		body:    testAttachmentBodyString,
 	},
 	{
 		section: "BODY[HEADER]",


### PR DESCRIPTION
When accessing part of a message using the index notation,
that is, BODY[1.2.3], IMAP servers do not include the MIME
header of the part.

Tested IRL by running Apple Mail against this server,
which likes to issue lots of BODY.PEEK[1.2.3]-style fetches.