### PR TITLE
imap: quote parameter values

### DIFF
--- a/message.go
+++ b/message.go
@@ -88,7 +88,7 @@ func ParseParamList(fields []interface{}) (map[string]string, error) {
 func FormatParamList(params map[string]string) []interface{} {
 	var fields []interface{}
 	for key, value := range params {
-		fields = append(fields, key, value)
+		fields = append(fields, key, Quoted(value))
 	}
 	return fields
 }

--- a/message_test.go
+++ b/message_test.go
@@ -400,7 +400,7 @@ var paramsListTest = []struct {
 		params: map[string]string{},
 	},
 	{
-		fields: []interface{}{"a", "b"},
+		fields: []interface{}{"a", Quoted("b")},
 		params: map[string]string{"a": "b"},
 	},
 }
@@ -454,7 +454,7 @@ var bodyStructureTests = []struct {
 		},
 	},
 	{
-		fields: []interface{}{"text", "plain", []interface{}{"charset", "utf-8"}, nil, nil, "us-ascii", "42", "2"},
+		fields: []interface{}{"text", "plain", []interface{}{"charset", Quoted("utf-8")}, nil, nil, "us-ascii", "42", "2"},
 		bodyStructure: &BodyStructure{
 			MIMEType:    "text",
 			MIMESubType: "plain",
@@ -495,7 +495,7 @@ var bodyStructureTests = []struct {
 		fields: []interface{}{
 			"application", "pdf", []interface{}{}, nil, nil, "base64", "4242",
 			"e0323a9039add2978bf5b49550572c7c",
-			[]interface{}{"attachment", []interface{}{"filename", "document.pdf"}},
+			[]interface{}{"attachment", []interface{}{"filename", Quoted("document.pdf")}},
 			[]interface{}{"en-US"}, []interface{}{},
 		},
 		bodyStructure: &BodyStructure{
@@ -545,7 +545,7 @@ var bodyStructureTests = []struct {
 	{
 		fields: []interface{}{
 			[]interface{}{"text", "plain", []interface{}{}, nil, nil, "us-ascii", "87", "22"},
-			"alternative", []interface{}{"hello", "world"},
+			"alternative", []interface{}{"hello", Quoted("world")},
 			[]interface{}{"inline", []interface{}{}},
 			[]interface{}{"en-US"}, []interface{}{},
 		},


### PR DESCRIPTION
An email from outlook.com contained an embedded part with
Content-ID and filename starting with a long sequence of
digits:

	279351849188E3D84D6DCC5B@namprd05.prod.outlook.com

When sent unquoted, the Apple Mail IMAP client attempts to
parse this initially as an integer. When it overflows a
uint32 parsing is stopped, so the message contents are never
displayed.

Quoting all parameter values is safe and avoids this.
Indeed the IMAP RFC includes examples of far more aggressive
quoting of almost all strings from a MIME message.
That may be worth considering in the future