### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/mailbox.go
+++ b/mailbox.go
@@ -12,7 +12,7 @@ import (
 // The primary mailbox, as defined in RFC 3501 section 5.1.
 const InboxName = "INBOX"
 
-// Returns the canonical form of a mailbox name. Mailbox names can be
+// CanonicalMailboxName returns the canonical form of a mailbox name. Mailbox names can be
 // case-sensitive or case-insensitive depending on the backend implementation.
 // The special INBOX mailbox is case-insensitive.
 func CanonicalMailboxName(name string) string {

--- a/message.go
+++ b/message.go
@@ -47,7 +47,7 @@ const (
 	MIMESpecifier = "MIME"
 )
 
-// Returns the canonical form of a flag. Flags are case-insensitive.
+// CanonicalFlag returns the canonical form of a flag. Flags are case-insensitive.
 //
 // If the flag is defined in RFC 3501, it returns the flag with the case of the
 // RFC. Otherwise, it returns the lowercase version of the flag.
@@ -312,7 +312,7 @@ func (m *Message) Format() []interface{} {
 	return fields
 }
 
-// Get the body section with the specified name. Returns nil if it's not found.
+// GetBody gets the body section with the specified name. Returns nil if it's not found.
 func (m *Message) GetBody(section *BodySectionName) Literal {
 	section = section.resp()
 

--- a/server/server.go
+++ b/server/server.go
@@ -281,7 +281,7 @@ func (s *Server) serveConn(conn Conn) error {
 	return conn.serve(conn)
 }
 
-// Get a command handler factory for the provided command name.
+// Command gets a command handler factory for the provided command name.
 func (s *Server) Command(name string) HandlerFactory {
 	// Extensions can override builtin commands
 	for _, ext := range s.extensions {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?