### PR TITLE
Pass basic connection information to backend

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,7 +1,11 @@
 // Package backend defines an IMAP server backend interface.
 package backend
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/emersion/go-imap"
+)
 
 // ErrInvalidCredentials is returned by Backend.Login when a username or a
 // password is incorrect.
@@ -12,5 +16,5 @@ var ErrInvalidCredentials = errors.New("Invalid credentials")
 type Backend interface {
 	// Login authenticates a user. If the username or the password is incorrect,
 	// it returns ErrInvalidCredentials.
-	Login(username, password string) (User, error)
+	Login(connInfo *imap.ConnInfo, username, password string) (User, error)
 }

--- a/backend/memory/backend.go
+++ b/backend/memory/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/backend"
 )
 
@@ -12,7 +13,7 @@ type Backend struct {
 	users map[string]*User
 }
 
-func (be *Backend) Login(username, password string) (backend.User, error) {
+func (be *Backend) Login(_ *imap.ConnInfo, username, password string) (backend.User, error) {
 	user, ok := be.users[username]
 	if ok && user.password == password {
 		return user, nil

--- a/server/cmd_noauth.go
+++ b/server/cmd_noauth.go
@@ -91,7 +91,7 @@ func (cmd *Login) Handle(conn Conn) error {
 		return ErrAuthDisabled
 	}
 
-	user, err := conn.Server().Backend.Login(cmd.Username, cmd.Password)
+	user, err := conn.Server().Backend.Login(conn.Info(), cmd.Username, cmd.Password)
 	if err != nil {
 		return err
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -34,6 +34,8 @@ type Conn interface {
 	Close() error
 	WaitReady()
 
+	Info() *imap.ConnInfo
+
 	setTLSConn(*tls.Conn)
 	silent() *bool // TODO: remove this
 	serve(Conn) error

--- a/server/server.go
+++ b/server/server.go
@@ -139,7 +139,7 @@ func New(bkd backend.Backend) *Server {
 					return errors.New("Identities not supported")
 				}
 
-				user, err := bkd.Login(username, password)
+				user, err := bkd.Login(conn.Info(), username, password)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Similar to go-smtp's ConnectionState. For https://github.com/emersion/maddy/issues/29. Breaking change.

Closes #232.