### PR TITLE
Change order of defer statements in tests

### DIFF
--- a/server/cmd_any_test.go
+++ b/server/cmd_any_test.go
@@ -21,8 +21,8 @@ func testServerGreeted(t *testing.T) (s *server.Server, c net.Conn, scanner *buf
 
 func TestCapability(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CAPABILITY\r\n")
 
@@ -39,8 +39,8 @@ func TestCapability(t *testing.T) {
 
 func TestNoop(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 NOOP\r\n")
 
@@ -52,8 +52,8 @@ func TestNoop(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LOGOUT\r\n")
 
@@ -80,8 +80,8 @@ func (ext *xnoop) Command(string) server.HandlerFactory {
 
 func TestServer_Enable(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	s.Enable(&xnoop{})
 
@@ -107,8 +107,8 @@ func (ext *xnoopAuth) Next(response []byte) (challenge []byte, done bool, err er
 
 func TestServer_EnableAuth(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	s.EnableAuth("XNOOP", func(server.Conn) sasl.Server {
 		return &xnoopAuth{}

--- a/server/cmd_auth_test.go
+++ b/server/cmd_auth_test.go
@@ -20,8 +20,8 @@ func testServerAuthenticated(t *testing.T) (s *server.Server, c net.Conn, scanne
 
 func TestSelect_Ok(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SELECT INBOX\r\n")
 
@@ -67,8 +67,8 @@ func TestSelect_Ok(t *testing.T) {
 
 func TestSelect_ReadOnly(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 EXAMINE INBOX\r\n")
 
@@ -89,8 +89,8 @@ func TestSelect_ReadOnly(t *testing.T) {
 
 func TestSelect_InvalidMailbox(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SELECT idontexist\r\n")
 
@@ -103,8 +103,8 @@ func TestSelect_InvalidMailbox(t *testing.T) {
 
 func TestSelect_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SELECT INBOX\r\n")
 	scanner.Scan()
@@ -115,8 +115,8 @@ func TestSelect_NotAuthenticated(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE test\r\n")
 	scanner.Scan()
@@ -128,8 +128,8 @@ func TestCreate(t *testing.T) {
 
 func TestCreate_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE test\r\n")
 	scanner.Scan()
@@ -140,8 +140,8 @@ func TestCreate_NotAuthenticated(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE test\r\n")
 	scanner.Scan()
@@ -156,8 +156,8 @@ func TestDelete(t *testing.T) {
 
 func TestDelete_InvalidMailbox(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 DELETE test\r\n")
 	scanner.Scan()
@@ -168,8 +168,8 @@ func TestDelete_InvalidMailbox(t *testing.T) {
 
 func TestDelete_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 DELETE INBOX\r\n")
 	scanner.Scan()
@@ -180,8 +180,8 @@ func TestDelete_NotAuthenticated(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE test\r\n")
 	scanner.Scan()
@@ -196,8 +196,8 @@ func TestRename(t *testing.T) {
 
 func TestRename_InvalidMailbox(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 RENAME test test2\r\n")
 	scanner.Scan()
@@ -208,8 +208,8 @@ func TestRename_InvalidMailbox(t *testing.T) {
 
 func TestRename_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 RENAME test test2\r\n")
 	scanner.Scan()
@@ -220,8 +220,8 @@ func TestRename_NotAuthenticated(t *testing.T) {
 
 func TestSubscribe(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SUBSCRIBE INBOX\r\n")
 	scanner.Scan()
@@ -238,8 +238,8 @@ func TestSubscribe(t *testing.T) {
 
 func TestSubscribe_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SUBSCRIBE INBOX\r\n")
 	scanner.Scan()
@@ -250,8 +250,8 @@ func TestSubscribe_NotAuthenticated(t *testing.T) {
 
 func TestUnsubscribe(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SUBSCRIBE INBOX\r\n")
 	scanner.Scan()
@@ -271,8 +271,8 @@ func TestUnsubscribe(t *testing.T) {
 
 func TestUnsubscribe_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UNSUBSCRIBE INBOX\r\n")
 	scanner.Scan()
@@ -283,8 +283,8 @@ func TestUnsubscribe_NotAuthenticated(t *testing.T) {
 
 func TestList(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LIST \"\" *\r\n")
 
@@ -301,8 +301,8 @@ func TestList(t *testing.T) {
 
 func TestList_Nested(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE first\r\n")
 	scanner.Scan()
@@ -371,8 +371,8 @@ func TestList_Nested(t *testing.T) {
 
 func TestList_Subscribed(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LSUB \"\" *\r\n")
 
@@ -399,8 +399,8 @@ func TestList_Subscribed(t *testing.T) {
 
 func TestList_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LIST \"\" *\r\n")
 	scanner.Scan()
@@ -411,8 +411,8 @@ func TestList_NotAuthenticated(t *testing.T) {
 
 func TestList_Delimiter(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LIST \"\" \"\"\r\n")
 
@@ -429,8 +429,8 @@ func TestList_Delimiter(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STATUS INBOX (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)\r\n")
 
@@ -454,8 +454,8 @@ func TestStatus(t *testing.T) {
 
 func TestStatus_InvalidMailbox(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STATUS idontexist (MESSAGES)\r\n")
 	scanner.Scan()
@@ -466,8 +466,8 @@ func TestStatus_InvalidMailbox(t *testing.T) {
 
 func TestStatus_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STATUS INBOX (MESSAGES)\r\n")
 	scanner.Scan()
@@ -478,8 +478,8 @@ func TestStatus_NotAuthenticated(t *testing.T) {
 
 func TestAppend(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND INBOX {80}\r\n")
 	scanner.Scan()
@@ -500,8 +500,8 @@ func TestAppend(t *testing.T) {
 
 func TestAppend_WithFlags(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND INBOX (\\Draft) {11}\r\n")
 	scanner.Scan()
@@ -519,8 +519,8 @@ func TestAppend_WithFlags(t *testing.T) {
 
 func TestAppend_WithFlagsAndDate(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND INBOX (\\Draft) \"5-Nov-1984 13:37:00 -0700\" {11}\r\n")
 	scanner.Scan()
@@ -538,8 +538,8 @@ func TestAppend_WithFlagsAndDate(t *testing.T) {
 
 func TestAppend_Selected(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND INBOX {11}\r\n")
 	scanner.Scan()
@@ -562,8 +562,8 @@ func TestAppend_Selected(t *testing.T) {
 
 func TestAppend_InvalidMailbox(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND idontexist {11}\r\n")
 	scanner.Scan()
@@ -581,8 +581,8 @@ func TestAppend_InvalidMailbox(t *testing.T) {
 
 func TestAppend_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 APPEND INBOX {11}\r\n")
 	scanner.Scan()

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestStartTLS(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	cert, err := tls.X509KeyPair(internal.LocalhostCert, internal.LocalhostKey)
 	if err != nil {
@@ -57,8 +57,8 @@ func TestStartTLS(t *testing.T) {
 
 func TestLogin_Ok(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LOGIN username password\r\n")
 
@@ -70,8 +70,8 @@ func TestLogin_Ok(t *testing.T) {
 
 func TestLogin_No(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 LOGIN username wrongpassword\r\n")
 
@@ -83,8 +83,8 @@ func TestLogin_No(t *testing.T) {
 
 func TestAuthenticate_Plain_Ok(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 AUTHENTICATE PLAIN\r\n")
 
@@ -104,8 +104,8 @@ func TestAuthenticate_Plain_Ok(t *testing.T) {
 
 func TestAuthenticate_Plain_No(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 AUTHENTICATE PLAIN\r\n")
 
@@ -125,8 +125,8 @@ func TestAuthenticate_Plain_No(t *testing.T) {
 
 func TestAuthenticate_No(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 AUTHENTICATE XIDONTEXIST\r\n")
 

--- a/server/cmd_selected_test.go
+++ b/server/cmd_selected_test.go
@@ -29,8 +29,8 @@ func testServerSelected(t *testing.T, readOnly bool) (s *server.Server, c net.Co
 
 func TestCheck(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CHECK\r\n")
 
@@ -42,8 +42,8 @@ func TestCheck(t *testing.T) {
 
 func TestCheck_ReadOnly(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CHECK\r\n")
 
@@ -55,8 +55,8 @@ func TestCheck_ReadOnly(t *testing.T) {
 
 func TestCheck_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CHECK\r\n")
 
@@ -68,8 +68,8 @@ func TestCheck_NotSelected(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CLOSE\r\n")
 
@@ -81,8 +81,8 @@ func TestClose(t *testing.T) {
 
 func TestClose_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CLOSE\r\n")
 
@@ -94,8 +94,8 @@ func TestClose_NotSelected(t *testing.T) {
 
 func TestExpunge(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 EXPUNGE\r\n")
 
@@ -126,8 +126,8 @@ func TestExpunge(t *testing.T) {
 
 func TestExpunge_ReadOnly(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 EXPUNGE\r\n")
 
@@ -139,8 +139,8 @@ func TestExpunge_ReadOnly(t *testing.T) {
 
 func TestExpunge_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 EXPUNGE\r\n")
 
@@ -152,8 +152,8 @@ func TestExpunge_NotSelected(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SEARCH UNDELETED\r\n")
 	scanner.Scan()
@@ -178,8 +178,8 @@ func TestSearch(t *testing.T) {
 
 func TestSearch_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 SEARCH UNDELETED\r\n")
 	scanner.Scan()
@@ -190,8 +190,8 @@ func TestSearch_NotSelected(t *testing.T) {
 
 func TestSearch_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UID SEARCH UNDELETED\r\n")
 	scanner.Scan()
@@ -206,8 +206,8 @@ func TestSearch_Uid(t *testing.T) {
 
 func TestFetch(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 FETCH 1 (UID FLAGS)\r\n")
 	scanner.Scan()
@@ -236,8 +236,8 @@ func TestFetch(t *testing.T) {
 
 func TestFetch_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UID FETCH 6 (UID)\r\n")
 	scanner.Scan()
@@ -252,8 +252,8 @@ func TestFetch_Uid(t *testing.T) {
 
 func TestFetch_Uid_UidNotRequested(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UID FETCH 6 (FLAGS)\r\n")
 	scanner.Scan()
@@ -268,8 +268,8 @@ func TestFetch_Uid_UidNotRequested(t *testing.T) {
 
 func TestStore(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STORE 1 +FLAGS (\\Flagged)\r\n")
 
@@ -317,8 +317,8 @@ func TestStore(t *testing.T) {
 
 func TestStore_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STORE 1 +FLAGS (\\Flagged)\r\n")
 	scanner.Scan()
@@ -329,8 +329,8 @@ func TestStore_NotSelected(t *testing.T) {
 
 func TestStore_ReadOnly(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STORE 1 +FLAGS (\\Flagged)\r\n")
 	scanner.Scan()
@@ -341,8 +341,8 @@ func TestStore_ReadOnly(t *testing.T) {
 
 func TestStore_InvalidOperation(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STORE 1 IDONTEXIST (\\Flagged)\r\n")
 	scanner.Scan()
@@ -353,8 +353,8 @@ func TestStore_InvalidOperation(t *testing.T) {
 
 func TestStore_InvalidFlags(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 STORE 1 +FLAGS somestring\r\n")
 	scanner.Scan()
@@ -389,8 +389,8 @@ func TestStore_NonList(t *testing.T) {
 
 func TestStore_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UID STORE 6 +FLAGS (\\Flagged)\r\n")
 
@@ -407,8 +407,8 @@ func TestStore_Uid(t *testing.T) {
 
 func TestCopy(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE CopyDest\r\n")
 	scanner.Scan()
@@ -435,8 +435,8 @@ func TestCopy(t *testing.T) {
 
 func TestCopy_NotSelected(t *testing.T) {
 	s, c, scanner := testServerAuthenticated(t)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE CopyDest\r\n")
 	scanner.Scan()
@@ -453,8 +453,8 @@ func TestCopy_NotSelected(t *testing.T) {
 
 func TestCopy_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 CREATE CopyDest\r\n")
 	scanner.Scan()
@@ -471,8 +471,8 @@ func TestCopy_Uid(t *testing.T) {
 
 func TestUid_InvalidCommand(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
-	defer c.Close()
 	defer s.Close()
+	defer c.Close()
 
 	io.WriteString(c, "a001 UID IDONTEXIST\r\n")
 	scanner.Scan()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -32,8 +32,8 @@ func testServer(t *testing.T) (s *server.Server, conn net.Conn) {
 
 func TestServer_greeting(t *testing.T) {
 	s, conn := testServer(t)
-	defer conn.Close()
 	defer s.Close()
+	defer conn.Close()
 
 	scanner := bufio.NewScanner(conn)
 


### PR DESCRIPTION
It removes flood of "use of closed connection" errors from stderr.