### PR TITLE
client: prepopulate tls.Config.ServerName

### DIFF
--- a/client/cmd_noauth.go
+++ b/client/cmd_noauth.go
@@ -35,6 +35,14 @@ func (c *Client) StartTLS(tlsConfig *tls.Config) error {
 		return ErrTLSAlreadyEnabled
 	}
 
+	if tlsConfig == nil {
+		tlsConfig = new(tls.Config)
+	}
+	if tlsConfig.ServerName == "" {
+		tlsConfig = tlsConfig.Clone()
+		tlsConfig.ServerName = c.serverName
+	}
+
 	cmd := new(commands.StartTLS)
 
 	err := c.Upgrade(func(conn net.Conn) (net.Conn, error) {


### PR DESCRIPTION
This allows library users to call Client.StartTLS and DialWithDialerTLS with
a nil tls.Config.