### PR TITLE
Fix missing first debug log

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -79,6 +79,25 @@ func newTestClient(t *testing.T) (c *Client, s *serverConn) {
 	return
 }
 
+func TestDialParam(t *testing.T) {
+	l, _ := net.Listen("tcp", "127.0.0.1:0")
+
+	defer func() {
+		if r := recover(); r != nil {
+			var ok bool
+			_, ok = r.(error)
+			if !ok {
+				if r != "1st parameter not type io.Writer." {
+					t.Errorf("Missing error msg: 1st parameter not type io.Writer.")
+				}
+			}
+		}
+	}()
+
+	Dial(l.Addr().String(), "incorrect type")
+	t.Errorf("Missing panic")
+}
+
 func setClientState(c *Client, state imap.ConnState, mailbox *imap.MailboxStatus) {
 	c.locker.Lock()
 	c.state = state


### PR DESCRIPTION
Hello,
I have a small fix related to logging. Due to implementation, there is impossible to start to debug mode from the beginning. So, I have a proposition to add not required parameter which will make this possible.  
There is an issue for that - https://github.com/emersion/go-imap/issues/175. 

What do you think about it? 