### PR TITLE
Revert "backendutil: Use textproto directly for Match"

### DIFF
--- a/backend/backendutil/search.go
+++ b/backend/backendutil/search.go
@@ -4,33 +4,33 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"net/mail"
 	"strings"
 	"time"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-message/textproto"
+	"github.com/emersion/go-message"
+	"github.com/emersion/go-message/mail"
 )
 
 func matchString(s, substr string) bool {
 	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }
 
-func bufferBody(body *io.Reader) (*bytes.Buffer, error) {
+func bufferBody(e *message.Entity) (*bytes.Buffer, error) {
 	b := new(bytes.Buffer)
-	if _, err := io.Copy(b, *body); err != nil {
+	if _, err := io.Copy(b, e.Body); err != nil {
 		return nil, err
 	}
-	*body = b
+	e.Body = b
 	return b, nil
 }
 
-func matchBody(body *io.Reader, substr string) (bool, error) {
-	if s, ok := (*body).(fmt.Stringer); ok {
+func matchBody(e *message.Entity, substr string) (bool, error) {
+	if s, ok := e.Body.(fmt.Stringer); ok {
 		return matchString(s.String(), substr), nil
 	}
 
-	b, err := bufferBody(body)
+	b, err := bufferBody(e)
 	if err != nil {
 		return false, err
 	}
@@ -41,12 +41,12 @@ type lengther interface {
 	Len() int
 }
 
-func bodyLen(body *io.Reader) (int, error) {
-	if l, ok := (*body).(lengther); ok {
+func bodyLen(e *message.Entity) (int, error) {
+	if l, ok := e.Body.(lengther); ok {
 		return l.Len(), nil
 	}
 
-	b, err := bufferBody(body)
+	b, err := bufferBody(e)
 	if err != nil {
 		return 0, err
 	}
@@ -55,16 +55,14 @@ func bodyLen(body *io.Reader) (int, error) {
 
 // Match returns true if a message and its metadata matches the provided
 // criteria.
-func Match(hdr textproto.Header, body io.Reader, seqNum, uid uint32, date time.Time, flags []string, c *imap.SearchCriteria) (bool, error) {
-	return match(hdr, &body, seqNum, uid, date, flags, c)
-}
-
-func match(hdr textproto.Header, body *io.Reader, seqNum, uid uint32, date time.Time, flags []string, c *imap.SearchCriteria) (bool, error) {
+func Match(e *message.Entity, seqNum, uid uint32, date time.Time, flags []string, c *imap.SearchCriteria) (bool, error) {
 	// TODO: support encoded header fields for Bcc, Cc, From, To
 	// TODO: add header size for Larger and Smaller
 
+	h := mail.Header{Header: e.Header}
+
 	if !c.SentBefore.IsZero() || !c.SentSince.IsZero() {
-		t, err := mail.ParseDate(hdr.Get("Date"))
+		t, err := h.Date()
 		if err != nil {
 			return false, err
 		}
@@ -79,14 +77,14 @@ func match(hdr textproto.Header, body *io.Reader, seqNum, uid uint32, date time.
 	}
 
 	for key, wantValues := range c.Header {
-		ok := hdr.Has(key)
+		ok := e.Header.Has(key)
 		for _, wantValue := range wantValues {
 			if wantValue == "" && !ok {
 				return false, nil
 			}
 			if wantValue != "" {
 				ok := false
-				values := hdr.FieldsByKey(key)
+				values := e.Header.FieldsByKey(key)
 				for values.Next() {
 					if matchString(values.Value(), wantValue) {
 						ok = true
@@ -99,20 +97,20 @@ func match(hdr textproto.Header, body *io.Reader, seqNum, uid uint32, date time.
 			}
 		}
 	}
-	for _, searchBody := range c.Body {
-		if ok, err := matchBody(body, searchBody); err != nil || !ok {
+	for _, body := range c.Body {
+		if ok, err := matchBody(e, body); err != nil || !ok {
 			return false, err
 		}
 	}
 	for _, text := range c.Text {
 		// TODO: also match header fields
-		if ok, err := matchBody(body, text); err != nil || !ok {
+		if ok, err := matchBody(e, text); err != nil || !ok {
 			return false, err
 		}
 	}
 
 	if c.Larger > 0 || c.Smaller > 0 {
-		n, err := bodyLen(body)
+		n, err := bodyLen(e)
 		if err != nil {
 			return false, err
 		}
@@ -144,18 +142,18 @@ func match(hdr textproto.Header, body *io.Reader, seqNum, uid uint32, date time.
 	}
 
 	for _, not := range c.Not {
-		ok, err := match(hdr, body, seqNum, uid, date, flags, not)
+		ok, err := Match(e, seqNum, uid, date, flags, not)
 		if err != nil || ok {
 			return false, err
 		}
 	}
 	for _, or := range c.Or {
-		ok1, err := match(hdr, body, seqNum, uid, date, flags, or[0])
+		ok1, err := Match(e, seqNum, uid, date, flags, or[0])
 		if err != nil {
 			return ok1, err
 		}
 
-		ok2, err := match(hdr, body, seqNum, uid, date, flags, or[1])
+		ok2, err := Match(e, seqNum, uid, date, flags, or[1])
 		if err != nil || (!ok1 && !ok2) {
 			return false, err
 		}

--- a/backend/backendutil/search_test.go
+++ b/backend/backendutil/search_test.go
@@ -1,14 +1,13 @@
 package backendutil
 
 import (
-	"bufio"
-	nettextproto "net/textproto"
+	"net/textproto"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-message/textproto"
+	"github.com/emersion/go-message"
 )
 
 var testInternalDate = time.Unix(1483997966, 0)
@@ -23,13 +22,13 @@ var matchTests = []struct {
 }{
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"From": {"Mitsuha"}},
+			Header: textproto.MIMEHeader{"From": {"Mitsuha"}},
 		},
 		res: true,
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"To": {"Mitsuha"}},
+			Header: textproto.MIMEHeader{"To": {"Mitsuha"}},
 		},
 		res: false,
 	},
@@ -66,25 +65,25 @@ var matchTests = []struct {
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Message-Id": {"42@example.org"}},
+			Header: textproto.MIMEHeader{"Message-Id": {"42@example.org"}},
 		},
 		res: true,
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Message-Id": {"43@example.org"}},
+			Header: textproto.MIMEHeader{"Message-Id": {"43@example.org"}},
 		},
 		res: false,
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Message-Id": {""}},
+			Header: textproto.MIMEHeader{"Message-Id": {""}},
 		},
 		res: true,
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Reply-To": {""}},
+			Header: textproto.MIMEHeader{"Reply-To": {""}},
 		},
 		res: false,
 	},
@@ -102,13 +101,13 @@ var matchTests = []struct {
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Subject": {"your"}},
+			Header: textproto.MIMEHeader{"Subject": {"your"}},
 		},
 		res: true,
 	},
 	{
 		criteria: &imap.SearchCriteria{
-			Header: nettextproto.MIMEHeader{"Subject": {"Taki"}},
+			Header: textproto.MIMEHeader{"Subject": {"Taki"}},
 		},
 		res: false,
 	},
@@ -295,13 +294,12 @@ var matchTests = []struct {
 
 func TestMatch(t *testing.T) {
 	for i, test := range matchTests {
-		bufferedBody := bufio.NewReader(strings.NewReader(testMailString))
-		hdr, err := textproto.ReadHeader(bufferedBody)
+		e, err := message.Read(strings.NewReader(testMailString))
 		if err != nil {
 			t.Fatal("Expected no error while reading entity, got:", err)
 		}
 
-		ok, err := Match(hdr, bufferedBody, test.seqNum, test.uid, test.date, test.flags, test.criteria)
+		ok, err := Match(e, test.seqNum, test.uid, test.date, test.flags, test.criteria)
 		if err != nil {
 			t.Fatal("Expected no error while matching entity, got:", err)
 		}

--- a/backend/memory/message.go
+++ b/backend/memory/message.go
@@ -69,6 +69,6 @@ func (m *Message) Fetch(seqNum uint32, items []imap.FetchItem) (*imap.Message, e
 }
 
 func (m *Message) Match(seqNum uint32, c *imap.SearchCriteria) (bool, error) {
-	hdr, body, _ := m.headerAndBody()
-	return backendutil.Match(hdr, body, seqNum, m.Uid, m.Date, m.Flags, c)
+	e, _ := m.entity()
+	return backendutil.Match(e, seqNum, m.Uid, m.Date, m.Flags, c)
 }


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc3501#page-50:
>The OPTIONAL [CHARSET] specification consists of the word
>"CHARSET" followed by a registered [CHARSET].  It indicates the
>[CHARSET] of the strings that appear in the search criteria.
>[MIME-IMB] content transfer encodings, **and [MIME-HDRS] strings in
>[RFC-2822]/[MIME-IMB] headers, MUST be decoded before comparing
>text in a [CHARSET] other than US-ASCII.**  US-ASCII MUST be
>supported; other [CHARSET]s MAY be supported.