### PR TITLE
backendutil: Decode headers in Match before comparsion

### DIFF
--- a/backend/backendutil/search.go
+++ b/backend/backendutil/search.go
@@ -86,10 +86,7 @@ func Match(e *message.Entity, seqNum, uid uint32, date time.Time, flags []string
 				ok := false
 				values := e.Header.FieldsByKey(key)
 				for values.Next() {
-					decoded, err := values.Text()
-					if err != nil {
-						continue
-					}
+					decoded, _ := values.Text()
 					if matchString(decoded, wantValue) {
 						ok = true
 						break

--- a/backend/backendutil/search.go
+++ b/backend/backendutil/search.go
@@ -86,7 +86,11 @@ func Match(e *message.Entity, seqNum, uid uint32, date time.Time, flags []string
 				ok := false
 				values := e.Header.FieldsByKey(key)
 				for values.Next() {
-					if matchString(values.Value(), wantValue) {
+					decoded, err := values.Text()
+					if err != nil {
+						continue
+					}
+					if matchString(decoded, wantValue) {
 						ok = true
 						break
 					}

--- a/backend/backendutil/search_test.go
+++ b/backend/backendutil/search_test.go
@@ -312,3 +312,51 @@ func TestMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchEncoded(t *testing.T) {
+	encodedTestMsg := `From: "fox.cpp" <foxcpp@foxcpp.dev>
+To: "fox.cpp" <foxcpp@foxcpp.dev>
+Subject: =?utf-8?B?0J/RgNC+0LLQtdGA0LrQsCE=?=
+Date: Sun, 09 Jun 2019 00:06:43 +0300
+MIME-Version: 1.0
+Message-ID: <a2aeb99e-52dd-40d3-b99f-1fdaad77ed98@foxcpp.dev>
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: quoted-printable
+
+=D0=AD=D1=82=D0=BE=D1=82 =D1=82=D0=B5=D0=BA=D1=81=D1=82 =D0=B4=D0=BE=D0=BB=
+=D0=B6=D0=B5=D0=BD =D0=B1=D1=8B=D1=82=D1=8C =D0=B7=D0=B0=D0=BA=D0=BE=D0=B4=
+=D0=B8=D1=80=D0=BE=D0=B2=D0=B0=D0=BD =D0=B2 base64 =D0=B8=D0=BB=D0=B8 quote=
+d-encoding.`
+	e, err := message.Read(strings.NewReader(encodedTestMsg))
+	if err != nil {
+		t.Fatal("Expected no error while reading entity, got:", err)
+	}
+
+	// Check encoded header.
+	crit := imap.SearchCriteria{
+		Header: textproto.MIMEHeader{"Subject": []string{"Проверка!"}},
+	}
+
+	ok, err := Match(e, 0, 0, time.Now(), []string{}, &crit)
+	if err != nil {
+		t.Fatal("Expected no error while matching entity, got:", err)
+	}
+
+	if !ok {
+		t.Error("Expected match for encoded header")
+	}
+
+	// Encoded body.
+	crit = imap.SearchCriteria{
+		Body: []string{"или"},
+	}
+
+	ok, err = Match(e, 0, 0, time.Now(), []string{}, &crit)
+	if err != nil {
+		t.Fatal("Expected no error while matching entity, got:", err)
+	}
+
+	if !ok {
+		t.Error("Expected match for encoded body")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/emersion/go-imap
 
 require (
-	github.com/emersion/go-message v0.10.3
+	github.com/emersion/go-message v0.10.4-0.20190609165112-592ace5bc1ca
 	github.com/emersion/go-sasl v0.0.0-20190520160400-47d427600317
 	golang.org/x/text v0.3.2
 )


### PR DESCRIPTION
After checking [RFC 2047](https://tools.ietf.org/html/rfc2047) I came to the conclusion that encoded values are allowed almost everywhere. Does it worth it checking whether a particular field is allowed to contain encoded values?

I also added a slightly extended test case I posted with the issue.
Closes #269.