### PR TITLE
client: Use non-synchronizing literals when length is small (<4096)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -585,8 +585,17 @@ func New(conn net.Conn) (*Client, error) {
 
 	c.handleContinuationReqs()
 	c.handleUnilateral()
-	err := c.handleGreetAndStartReading()
-	return c, err
+	if err := c.handleGreetAndStartReading(); err != nil {
+		return c, err
+	}
+
+	plusOk, _ := c.Support("LITERAL+")
+	minusOk, _ := c.Support("LITERAL-")
+	// We don't use non-sync literal if it is bigger than 4096 bytes, so
+	// LITERAL- is fine too.
+	c.conn.AllowUnsyncLiterals = plusOk || minusOk
+
+	return c, nil
 }
 
 // Dial connects to an IMAP server using an unencrypted connection.

--- a/client/client.go
+++ b/client/client.go
@@ -593,7 +593,7 @@ func New(conn net.Conn) (*Client, error) {
 	minusOk, _ := c.Support("LITERAL-")
 	// We don't use non-sync literal if it is bigger than 4096 bytes, so
 	// LITERAL- is fine too.
-	c.conn.AllowUnsyncLiterals = plusOk || minusOk
+	c.conn.AllowAsyncLiterals = plusOk || minusOk
 
 	return c, nil
 }

--- a/write.go
+++ b/write.go
@@ -49,7 +49,7 @@ func isAscii(s string) bool {
 type Writer struct {
 	io.Writer
 
-	AllowUnsyncLiterals bool
+	AllowAsyncLiterals bool
 
 	continues <-chan bool
 }
@@ -125,7 +125,7 @@ func (w *Writer) writeLiteral(l Literal) error {
 		return w.writeString(nilAtom)
 	}
 
-	unsyncLiteral := w.AllowUnsyncLiterals && l.Len() <= 4096
+	unsyncLiteral := w.AllowAsyncLiterals && l.Len() <= 4096
 
 	header := string(literalStart) + strconv.Itoa(l.Len())
 	if unsyncLiteral {

--- a/write.go
+++ b/write.go
@@ -49,6 +49,8 @@ func isAscii(s string) bool {
 type Writer struct {
 	io.Writer
 
+	AllowUnsyncLiterals bool
+
 	continues <-chan bool
 }
 
@@ -123,13 +125,19 @@ func (w *Writer) writeLiteral(l Literal) error {
 		return w.writeString(nilAtom)
 	}
 
-	header := string(literalStart) + strconv.Itoa(l.Len()) + string(literalEnd) + crlf
+	unsyncLiteral := w.AllowUnsyncLiterals && l.Len() <= 4096
+
+	header := string(literalStart) + strconv.Itoa(l.Len())
+	if unsyncLiteral {
+		header += string('+')
+	}
+	header += string(literalEnd) + crlf
 	if err := w.writeString(header); err != nil {
 		return err
 	}
 
 	// If a channel is available, wait for a continuation request before sending data
-	if w.continues != nil {
+	if !unsyncLiteral && w.continues != nil {
 		// Make sure to flush the writer, otherwise we may never receive a continuation request
 		if err := w.Flush(); err != nil {
 			return err

--- a/write_test.go
+++ b/write_test.go
@@ -2,6 +2,7 @@ package imap
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 )
@@ -197,6 +198,35 @@ func TestWriter_WriteField_Literal(t *testing.T) {
 		t.Error(err)
 	}
 	if b.String() != "{11}\r\nhello world" {
+		t.Error("Not the expected literal")
+	}
+}
+
+func TestWriter_WriteField_NonSyncLiteral(t *testing.T) {
+	w, b := newWriter()
+	w.AllowUnsyncLiterals = true
+
+	literal := bytes.NewBufferString("hello world")
+
+	if err := w.writeField(literal); err != nil {
+		t.Error(err)
+	}
+	if b.String() != "{11+}\r\nhello world" {
+		t.Error("Not the expected literal")
+	}
+}
+
+func TestWriter_WriteField_LargeNonSyncLiteral(t *testing.T) {
+	w, b := newWriter()
+	w.AllowUnsyncLiterals = true
+
+	s := strings.Repeat("A", 4097)
+	literal := bytes.NewBufferString(s)
+
+	if err := w.writeField(literal); err != nil {
+		t.Error(err)
+	}
+	if b.String() != "{4097}\r\n"+s {
 		t.Error("Not the expected literal")
 	}
 }

--- a/write_test.go
+++ b/write_test.go
@@ -204,7 +204,7 @@ func TestWriter_WriteField_Literal(t *testing.T) {
 
 func TestWriter_WriteField_NonSyncLiteral(t *testing.T) {
 	w, b := newWriter()
-	w.AllowUnsyncLiterals = true
+	w.AllowAsyncLiterals = true
 
 	literal := bytes.NewBufferString("hello world")
 
@@ -218,7 +218,7 @@ func TestWriter_WriteField_NonSyncLiteral(t *testing.T) {
 
 func TestWriter_WriteField_LargeNonSyncLiteral(t *testing.T) {
 	w, b := newWriter()
-	w.AllowUnsyncLiterals = true
+	w.AllowAsyncLiterals = true
 
 	s := strings.Repeat("A", 4097)
 	literal := bytes.NewBufferString(s)


### PR DESCRIPTION
Closes #7.