### PR TITLE
backendutil: Handle BODY[1] for non-multipart messages

### DIFF
--- a/backend/backendutil/body.go
+++ b/backend/backendutil/body.go
@@ -36,6 +36,11 @@ func FetchBodySection(header textproto.Header, body io.Reader, section *imap.Bod
 
 		mr := multipartReader(header, body)
 		if mr == nil {
+			// First part of non-multipart message refers to the message itself.
+			// See RFC 3501, Page 55.
+			if len(section.Path) == 1 && section.Path[0] == 1 {
+				break
+			}
 			return nil, errNoSuchPart
 		}
 


### PR DESCRIPTION
This is partial implementation since BODY[something.1] should be also handled for nested messages, but FetchBodySection doesn't seem to support nested messages at all, so let's leave it for another time.