### PR TITLE
backendutil: fix header parsing in FetchEnvelope

### DIFF
--- a/backend/backendutil/backendutil_test.go
+++ b/backend/backendutil/backendutil_test.go
@@ -16,6 +16,16 @@ const testHeaderString = "Content-Type: multipart/mixed; boundary=message-bounda
 	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
 	"\r\n"
 
+const testBase64HeaderString = "Content-Type: multipart/mixed; boundary=message-boundary\r\n" +
+	"Date: Sat, 18 Jun 2016 12:00:00 +0900\r\n" +
+	"Date: Sat, 19 Jun 2016 12:00:00 +0900\r\n" +
+	"From: =?ISO-8859-15?B?TWl0c3VoYSBNaXlhbWl6dQ==?= <mitsuha.miyamizu@example.org>\r\n" +
+	"Reply-To: =?ISO-8859-15?B?TWl0c3VoYSBNaXlhbWl6dQ==?= <mitsuha.miyamizu+replyto@example.org>\r\n" +
+	"Message-Id: 42@example.org\r\n" +
+	"Subject: Your Name.\r\n" +
+	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
+	"\r\n"
+
 const testHeaderFromToString = "From: Mitsuha Miyamizu <mitsuha.miyamizu@example.org>\r\n" +
 	"To: Taki Tachibana <taki.tachibana@example.org>\r\n" +
 	"\r\n"
@@ -77,3 +87,4 @@ const testBodyString = "--message-boundary\r\n" +
 	"\r\n--message-boundary--\r\n"
 
 const testMailString = testHeaderString + testBodyString
+const testBase64MailString = testBase64HeaderString + testBodyString

--- a/backend/backendutil/envelope.go
+++ b/backend/backendutil/envelope.go
@@ -5,11 +5,16 @@ import (
 	"strings"
 
 	"github.com/emersion/go-imap"
+	"github.com/emersion/go-message/charset"
 	"github.com/emersion/go-message/textproto"
 )
 
 func headerAddressList(value string) ([]*imap.Address, error) {
-	addrs, err := mail.ParseAddressList(value)
+	decodedValue, err := charset.DecodeHeader(value)
+	if err != nil {
+		return []*imap.Address{}, err
+	}
+	addrs, err := mail.ParseAddressList(decodedValue)
 	if err != nil {
 		return []*imap.Address{}, err
 	}

--- a/backend/backendutil/envelope_test.go
+++ b/backend/backendutil/envelope_test.go
@@ -38,3 +38,19 @@ func TestFetchEnvelope(t *testing.T) {
 		t.Errorf("Expected envelope \n%+v\n but got \n%+v", testEnvelope, env)
 	}
 }
+
+func TestFetchEnvelopeBase64(t *testing.T) {
+	hdr, err := textproto.ReadHeader(bufio.NewReader(strings.NewReader(testBase64MailString)))
+	if err != nil {
+		t.Fatal("Expected no error while reading mail, got:", err)
+	}
+
+	env, err := FetchEnvelope(hdr)
+	if err != nil {
+		t.Fatal("Expected no error while fetching envelope, got:", err)
+	}
+
+	if !reflect.DeepEqual(env, testEnvelope) {
+		t.Errorf("Expected envelope \n%+v\n but got \n%+v", testEnvelope, env)
+	}
+}

--- a/backend/backendutil/envelope_test.go
+++ b/backend/backendutil/envelope_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/emersion/go-imap"
+	"github.com/emersion/go-message/charset"
 	"github.com/emersion/go-message/textproto"
 )
 
@@ -49,8 +50,14 @@ func TestFetchEnvelopeBase64(t *testing.T) {
 	if err != nil {
 		t.Fatal("Expected no error while fetching envelope, got:", err)
 	}
-
-	if !reflect.DeepEqual(env, testEnvelope) {
-		t.Errorf("Expected envelope \n%+v\n but got \n%+v", testEnvelope, env)
+	if len(env.From) != 1 {
+		t.Fatal("Expected 1 address in envelope.From, got", len(env.From))
+	}
+	from, err := charset.DecodeHeader(env.From[0].PersonalName)
+	if err != nil {
+		t.Fatal("Expected no error while decoding PersonalName, got", err)
+	}
+	if from != testEnvelope.From[0].PersonalName {
+		t.Errorf("Expected PersonalName \n%+v\n, but got \n%+v", testEnvelope.From[0].PersonalName, from)
 	}
 }


### PR DESCRIPTION
this PR fixes #279  by modifying `headerAddressList`. Just decode the value before feeding it to `ParseAddressList`.  

Maybe we should decode all other fields like `Subject` too?