### PR TITLE
Don't send CAPABILITY statement unsolicited after starting TLS connections. 

### DIFF
--- a/server/cmd_noauth.go
+++ b/server/cmd_noauth.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/commands"
-	"github.com/emersion/go-imap/responses"
 	"github.com/emersion/go-sasl"
 )
 
@@ -57,8 +56,7 @@ func (cmd *StartTLS) Upgrade(conn Conn) error {
 
 	conn.setTLSConn(tlsConn)
 
-	res := &responses.Capability{Caps: conn.Capabilities()}
-	return conn.WriteResp(res)
+	return nil
 }
 
 func afterAuthStatus(conn Conn) error {

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -47,6 +47,7 @@ func TestStartTLS(t *testing.T) {
 	if err = sc.Handshake(); err != nil {
 		t.Fatal(err)
 	}
+	io.WriteString(sc, "a001 CAPABILITY\r\n")
 	scanner = bufio.NewScanner(sc)
 
 	scanner.Scan()


### PR DESCRIPTION
Clients should be re-requesting it as per https://tools.ietf.org/html/rfc3501#section-6.2.1.

This fixes k9 mail for Android, which gets confused by receiving an unsolicited command straight after the TLS connection has been made. 