### PR TITLE
Make SEARCH charset a RawString

### DIFF
--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -125,7 +125,7 @@ func TestClient_Search(t *testing.T) {
 		done <- err
 	}()
 
-	wantCmd := `SEARCH CHARSET "UTF-8" SINCE "1-Feb-1994" FROM "Smith" DELETED NOT (TO "Pauline")`
+	wantCmd := `SEARCH CHARSET UTF-8 SINCE "1-Feb-1994" FROM "Smith" DELETED NOT (TO "Pauline")`
 	tag, cmd := s.ScanCmd()
 	if cmd != wantCmd {
 		t.Fatalf("client sent command %v, want %v", cmd, wantCmd)
@@ -162,7 +162,7 @@ func TestClient_Search_Uid(t *testing.T) {
 		done <- err
 	}()
 
-	wantCmd := "UID SEARCH CHARSET \"UTF-8\" UNDELETED"
+	wantCmd := "UID SEARCH CHARSET UTF-8 UNDELETED"
 	tag, cmd := s.ScanCmd()
 	if cmd != wantCmd {
 		t.Fatalf("client sent command %v, want %v", cmd, wantCmd)

--- a/commands/search.go
+++ b/commands/search.go
@@ -17,7 +17,7 @@ type Search struct {
 func (cmd *Search) Command() *imap.Command {
 	var args []interface{}
 	if cmd.Charset != "" {
-		args = append(args, imap.RawString("CHARSET"), cmd.Charset)
+		args = append(args, imap.RawString("CHARSET"), imap.RawString(cmd.Charset))
 	}
 	args = append(args, cmd.Criteria.Format()...)
 


### PR DESCRIPTION
Right now, the SEARCH command sends something like this:

>  PMn5AW UID SEARCH CHARSET "UTF-8" 1:*

However, those quotes surrounding "UTF-8" seem to be troublesome, at least when talking to the GreenMail server (http://www.icegreen.com/greenmail).

Reading the RFC (https://tools.ietf.org/html/rfc3501#page-49) does not help to understand if those quotes are required or not **but** searching on google for "UID SEARCH CHARSET" seems to return results where quotes are not being used.

This Pull Request removes those quotes (and now GreenMail works as expected).

In any case, feel free to discard this PR if you consider this is something that should be fixed in GreenMail's source code instead of here.

Thanks!

