### PR TITLE
Lots of Server-side fixes and improvements

### DIFF
--- a/backend/backendutil/flags_test.go
+++ b/backend/backendutil/flags_test.go
@@ -32,6 +32,12 @@ var updateFlagsTests = []struct {
 		flags: []string{"a", "d", "e"},
 		res:   []string{"a", "d", "e"},
 	},
+	// Test unknown op for code coverage.
+	{
+		op:    imap.FlagsOp("TestUnknownOp"),
+		flags: []string{"a", "d", "e"},
+		res:   []string{"a", "b", "c"},
+	},
 }
 
 func TestUpdateFlags(t *testing.T) {
@@ -51,5 +57,30 @@ func TestUpdateFlags(t *testing.T) {
 			t.Errorf("Unexpected change to operation flags list changed \nbefore %v\n after \n%v",
 				origFlags, test.flags)
 		}
+	}
+}
+
+func TestUpdateFlags_Recent(t *testing.T) {
+	current := []string{}
+
+	current = UpdateFlags(current, imap.SetFlags, []string{imap.RecentFlag})
+
+	res := []string{imap.RecentFlag}
+	if !reflect.DeepEqual(current, res) {
+		t.Errorf("Expected result to be \n%v\n but got \n%v", res, current)
+	}
+
+	current = UpdateFlags(current, imap.SetFlags, []string{"something"})
+
+	res = []string{imap.RecentFlag, "something"}
+	if !reflect.DeepEqual(current, res) {
+		t.Errorf("Expected result to be \n%v\n but got \n%v", res, current)
+	}
+
+	current = UpdateFlags(current, imap.SetFlags, []string{"another", imap.RecentFlag})
+
+	res = []string{imap.RecentFlag, "another"}
+	if !reflect.DeepEqual(current, res) {
+		t.Errorf("Expected result to be \n%v\n but got \n%v", res, current)
 	}
 }

--- a/backend/backendutil/flags_test.go
+++ b/backend/backendutil/flags_test.go
@@ -35,12 +35,21 @@ var updateFlagsTests = []struct {
 }
 
 func TestUpdateFlags(t *testing.T) {
-	current := []string{"a", "b", "c"}
+	flagsList := []string{"a", "b", "c"}
 	for _, test := range updateFlagsTests {
-		got := UpdateFlags(current[:], test.op, test.flags)
+		// Make a backup copy of 'test.flags'
+		origFlags := append(test.flags[:0:0], test.flags...)
+		// Copy flags
+		current := append(flagsList[:0:0], flagsList...)
+		got := UpdateFlags(current, test.op, test.flags)
 
 		if !reflect.DeepEqual(got, test.res) {
 			t.Errorf("Expected result to be \n%v\n but got \n%v", test.res, got)
+		}
+		// Verify that 'test.flags' wasn't modified
+		if !reflect.DeepEqual(origFlags, test.flags) {
+			t.Errorf("Unexpected change to operation flags list changed \nbefore %v\n after \n%v",
+				origFlags, test.flags)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/emersion/go-imap
 require (
 	github.com/emersion/go-message v0.10.4-0.20190609165112-592ace5bc1ca
 	github.com/emersion/go-sasl v0.0.0-20190520160400-47d427600317
+	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/text v0.3.2
 )

--- a/server/cmd_auth.go
+++ b/server/cmd_auth.go
@@ -147,20 +147,27 @@ func (cmd *List) Handle(conn Conn) error {
 
 	done := make(chan error, 1)
 	go (func() {
-		done <- conn.WriteResp(res)
-		close(done)
+		err := conn.WriteResp(res)
+		// Make sure to drain the channel.
+		for _ = range ch {
+		}
+		done <- err
 	})()
 
 	mailboxes, err := ctx.User.ListMailboxes(cmd.Subscribed)
 	if err != nil {
+		// Close channel and clear done channel
 		close(ch)
+		<-done
 		return err
 	}
 
 	for _, mbox := range mailboxes {
 		info, err := mbox.Info()
 		if err != nil {
+			// Close channel and clear done channel
 			close(ch)
+			<-done
 			return err
 		}
 

--- a/server/cmd_auth.go
+++ b/server/cmd_auth.go
@@ -41,6 +41,9 @@ func (cmd *Select) Handle(conn Conn) error {
 
 	ctx.Mailbox = mbox
 	ctx.MailboxReadOnly = cmd.ReadOnly || status.ReadOnly
+	// Update Mbox listener
+	s := conn.Server()
+	s.updateMboxListener(conn, ctx.User.Username(), mbox.Name())
 
 	res := &responses.Select{Mailbox: status}
 	if err := conn.WriteResp(res); err != nil {

--- a/server/cmd_auth_test.go
+++ b/server/cmd_auth_test.go
@@ -397,6 +397,18 @@ func TestList_Subscribed(t *testing.T) {
 	}
 }
 
+func TestTLS_AlreadyAuthenticated(t *testing.T) {
+	s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 STARTTLS\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+}
+
 func TestList_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
 	defer s.Close()

--- a/server/cmd_noauth.go
+++ b/server/cmd_noauth.go
@@ -104,6 +104,9 @@ func (cmd *Login) Handle(conn Conn) error {
 
 	ctx.State = imap.AuthenticatedState
 	ctx.User = user
+	// Update Mbox listener
+	s := conn.Server()
+	s.updateMboxListener(conn, user.Username(), "")
 	return afterAuthStatus(conn)
 }
 

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"io"
 	"log"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -13,10 +14,8 @@ import (
 	"github.com/emersion/go-imap/server"
 )
 
-func TestStartTLS(t *testing.T) {
-	s, c, scanner := testServerGreeted(t)
-	defer s.Close()
-	defer c.Close()
+func testServerTLS(t *testing.T) (s *server.Server, c net.Conn, scanner *bufio.Scanner) {
+	s, c, scanner = testServerGreeted(t)
 
 	cert, err := tls.X509KeyPair(internal.LocalhostCert, internal.LocalhostKey)
 	if err != nil {
@@ -50,11 +49,44 @@ func TestStartTLS(t *testing.T) {
 	if err = sc.Handshake(); err != nil {
 		t.Fatal(err)
 	}
+	c = sc
 	scanner = bufio.NewScanner(sc)
 
 	scanner.Scan()
 	if scanner.Text() != "* CAPABILITY IMAP4rev1 LITERAL+ SASL-IR AUTH=PLAIN" {
 		t.Fatal("Bad CAPABILITY response:", scanner.Text())
+	}
+
+	return
+}
+
+func TestStartTLS(t *testing.T) {
+	s, c, _ := testServerTLS(t)
+	defer s.Close()
+	defer c.Close()
+}
+
+func TestStartTLS_AlreadyEnabled(t *testing.T) {
+	s, c, scanner := testServerTLS(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 STARTTLS\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Bad status response:", scanner.Text())
+	}
+}
+
+func TestStartTLS_NotSupported(t *testing.T) {
+	s, c, scanner := testServerGreeted(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 STARTTLS\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Bad status response:", scanner.Text())
 	}
 }
 

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -124,8 +124,8 @@ func TestLogin_AlreadyAuthenticated(t *testing.T) {
 }
 
 func TestLogin_AutoLogout(t *testing.T) {
-	server.SetMinAutoLogout(1 * time.Second)
 	s, c, scanner := testServerGreeted(t)
+	s.MinAutoLogout = 1 * time.Second
 	defer s.Close()
 	defer c.Close()
 	s.AutoLogout = 2 * time.Second

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -103,6 +103,26 @@ func TestLogin_Ok(t *testing.T) {
 	}
 }
 
+func TestLogin_AlreadyAuthenticated(t *testing.T) {
+	s, c, scanner := testServerGreeted(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 LOGIN username password\r\n")
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Bad status response:", scanner.Text())
+	}
+
+	io.WriteString(c, "a001 LOGIN username password\r\n")
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Bad status response:", scanner.Text())
+	}
+}
+
 func TestLogin_AutoLogout(t *testing.T) {
 	server.SetMinAutoLogout(1 * time.Second)
 	s, c, scanner := testServerGreeted(t)

--- a/server/cmd_selected.go
+++ b/server/cmd_selected.go
@@ -207,13 +207,22 @@ func (cmd *Store) handle(uid bool, conn Conn) error {
 		return err
 	}
 
-	flagsList, ok := cmd.Value.([]interface{})
-	if !ok {
-		return errors.New("Flags must be a list")
-	}
-	flags, err := imap.ParseStringList(flagsList)
-	if err != nil {
-		return err
+	var flags []string
+
+	if flagsList, ok := cmd.Value.([]interface{}); ok {
+		// Parse list of flags
+		if strs, err := imap.ParseStringList(flagsList); err == nil {
+			flags = strs
+		} else {
+			return err
+		}
+	} else {
+		// Parse single flag
+		if str, err := imap.ParseString(cmd.Value); err == nil {
+			flags = []string{str}
+		} else {
+			return err
+		}
 	}
 	for i, flag := range flags {
 		flags[i] = imap.CanonicalFlag(flag)

--- a/server/cmd_selected.go
+++ b/server/cmd_selected.go
@@ -103,7 +103,13 @@ func (cmd *Expunge) Handle(conn Conn) error {
 		// Iterate sequence numbers from the last one to the first one, as deleting
 		// messages changes their respective numbers
 		for i := len(seqnums) - 1; i >= 0; i-- {
-			ch <- seqnums[i]
+			// Send sequence numbers to channel, and check if conn.WriteResp() finished early.
+			select {
+			case ch <- seqnums[i]: // Send next seq. number
+			case err := <-done: // Check for errors
+				close(ch)
+				return err
+			}
 		}
 		close(ch)
 
@@ -157,7 +163,11 @@ func (cmd *Fetch) handle(uid bool, conn Conn) error {
 
 	done := make(chan error, 1)
 	go (func() {
-		done <- conn.WriteResp(res)
+		err := conn.WriteResp(res)
+		// Make sure to drain the message channel.
+		for _ = range ch {
+		}
+		done <- err
 	})()
 
 	err := ctx.Mailbox.ListMessages(uid, cmd.SeqSet, cmd.Items, ch)

--- a/server/cmd_selected_test.go
+++ b/server/cmd_selected_test.go
@@ -234,6 +234,18 @@ func TestFetch(t *testing.T) {
 	}
 }
 
+func TestFetch_NotSelected(t *testing.T) {
+	s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 FETCH 1 (UID FLAGS)\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+}
+
 func TestFetch_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, true)
 	defer s.Close()

--- a/server/cmd_selected_test.go
+++ b/server/cmd_selected_test.go
@@ -412,6 +412,52 @@ func TestStore_NonList(t *testing.T) {
 	}
 }
 
+func TestStore_RecentFlag(t *testing.T) {
+	s, c, scanner := testServerSelected(t, false)
+	defer c.Close()
+	defer s.Close()
+
+	// Add Recent flag
+	io.WriteString(c, "a001 STORE 1 FLAGS \\Recent\r\n")
+
+	scanner.Scan()
+	if scanner.Text() != "* 1 FETCH (FLAGS (\\Recent))" {
+		t.Fatal("Invalid FETCH response:", scanner.Text())
+	}
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+
+	// Set flags to: something
+	// Should still get Recent flag back
+	io.WriteString(c, "a001 STORE 1 FLAGS something\r\n")
+
+	scanner.Scan()
+	if scanner.Text() != "* 1 FETCH (FLAGS (\\Recent something))" {
+		t.Fatal("Invalid FETCH response:", scanner.Text())
+	}
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+
+	// Try adding Recent flag again
+	io.WriteString(c, "a001 STORE 1 FLAGS \\Recent anotherflag\r\n")
+
+	scanner.Scan()
+	if scanner.Text() != "* 1 FETCH (FLAGS (\\Recent anotherflag))" {
+		t.Fatal("Invalid FETCH response:", scanner.Text())
+	}
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+}
+
 func TestStore_Uid(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
 	defer s.Close()

--- a/server/cmd_selected_test.go
+++ b/server/cmd_selected_test.go
@@ -27,6 +27,19 @@ func testServerSelected(t *testing.T, readOnly bool) (s *server.Server, c net.Co
 	return
 }
 
+func TestNoop_Selected(t *testing.T) {
+	s, c, scanner := testServerSelected(t, false)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 NOOP\r\n")
+
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Bad status response:", scanner.Text())
+	}
+}
+
 func TestCheck(t *testing.T) {
 	s, c, scanner := testServerSelected(t, false)
 	defer s.Close()

--- a/server/conn.go
+++ b/server/conn.go
@@ -136,8 +136,8 @@ func (c *conn) setDeadline() {
 	}
 
 	dur := c.s.AutoLogout
-	if dur < MinAutoLogout {
-		dur = MinAutoLogout
+	if dur < c.s.MinAutoLogout {
+		dur = c.s.MinAutoLogout
 	}
 	t := time.Now().Add(dur)
 

--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,13 @@ import (
 )
 
 // The minimum autologout duration defined in RFC 3501 section 5.4.
-const MinAutoLogout = 30 * time.Minute
+var (
+	MinAutoLogout = 30 * time.Minute
+)
+
+func SetMinAutoLogout(dur time.Duration) {
+	MinAutoLogout = dur
+}
 
 // A command handler.
 type Handler interface {

--- a/server/server.go
+++ b/server/server.go
@@ -18,15 +18,6 @@ import (
 	"github.com/emersion/go-sasl"
 )
 
-// The minimum autologout duration defined in RFC 3501 section 5.4.
-var (
-	MinAutoLogout = 30 * time.Minute
-)
-
-func SetMinAutoLogout(dur time.Duration) {
-	MinAutoLogout = dur
-}
-
 // A command handler.
 type Handler interface {
 	imap.Parser
@@ -122,6 +113,8 @@ type Server struct {
 	// automatically, set this to zero. The duration MUST be at least
 	// MinAutoLogout (as stated in RFC 3501 section 5.4).
 	AutoLogout time.Duration
+	// MinAutoLogout can be overridden, but RFC 3501 says it MUST be at least 30 minutes.
+	MinAutoLogout time.Duration
 	// Allow authentication over unencrypted connections.
 	AllowInsecureAuth bool
 	// An io.Writer to which all network activity will be mirrored.
@@ -143,6 +136,8 @@ func New(bkd backend.Backend) *Server {
 		conns:     make(map[Conn]*mboxListener),
 		Backend:   bkd,
 		ErrorLog:  log.New(os.Stderr, "imap/server: ", log.LstdFlags),
+		// The minimum autologout duration defined in RFC 3501 section 5.4.
+		MinAutoLogout: 30 * time.Minute,
 	}
 
 	s.auths = map[string]SASLServerFactory{

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -87,11 +88,17 @@ func ErrNoStatusResp() error {
 	return &errStatusResp{nil}
 }
 
+type mboxListener struct {
+	user    string
+	mailbox string
+	silent  bool
+}
+
 // An IMAP server.
 type Server struct {
 	locker    sync.Mutex
 	listeners map[net.Listener]struct{}
-	conns     map[Conn]struct{}
+	conns     map[Conn]*mboxListener
 
 	commands   map[string]HandlerFactory
 	auths      map[string]SASLServerFactory
@@ -127,7 +134,7 @@ type Server struct {
 func New(bkd backend.Backend) *Server {
 	s := &Server{
 		listeners: make(map[net.Listener]struct{}),
-		conns:     make(map[Conn]struct{}),
+		conns:     make(map[Conn]*mboxListener),
 		Backend:   bkd,
 		ErrorLog:  log.New(os.Stderr, "imap/server: ", log.LstdFlags),
 	}
@@ -268,7 +275,7 @@ func (s *Server) ListenAndServeTLS() error {
 
 func (s *Server) serveConn(conn Conn) error {
 	s.locker.Lock()
-	s.conns[conn] = struct{}{}
+	s.conns[conn] = &mboxListener{}
 	s.locker.Unlock()
 
 	defer func() {
@@ -281,6 +288,23 @@ func (s *Server) serveConn(conn Conn) error {
 	return conn.serve(conn)
 }
 
+func (s *Server) updateMboxListener(conn Conn, user string, mailbox string) {
+	s.locker.Lock()
+	if sub, ok := s.conns[conn]; ok {
+		sub.user = user
+		sub.mailbox = mailbox
+	}
+	s.locker.Unlock()
+}
+
+func (s *Server) silentMboxListener(conn Conn, silent bool) {
+	s.locker.Lock()
+	if sub, ok := s.conns[conn]; ok {
+		sub.silent = silent
+	}
+	s.locker.Unlock()
+}
+
 // Command gets a command handler factory for the provided command name.
 func (s *Server) Command(name string) HandlerFactory {
 	// Extensions can override builtin commands
@@ -291,6 +315,24 @@ func (s *Server) Command(name string) HandlerFactory {
 	}
 
 	return s.commands[name]
+}
+
+type bufResp struct {
+	bytes.Buffer
+}
+
+func (br *bufResp) WriteTo(w *imap.Writer) error {
+	_, err := w.Write(br.Buffer.Bytes())
+	return err
+}
+
+func bufferResp(res imap.WriterTo) (imap.WriterTo, error) {
+	buf := bufResp{}
+	bufWriter := imap.NewWriter(&buf)
+	if err := res.WriteTo(bufWriter); err != nil {
+		return nil, err
+	}
+	return &buf, nil
 }
 
 func (s *Server) listenUpdates() {
@@ -321,52 +363,40 @@ func (s *Server) listenUpdates() {
 		if res == nil {
 			continue
 		}
+		// Write response to buffer, so we can send it to multiple connections.
+		buf, err := bufferResp(res)
+		if err != nil {
+			s.ErrorLog.Printf("Failed to buffer update: %s\n", err)
+			continue
+		}
 
-		sends := make(chan struct{})
-		wait := 0
 		s.locker.Lock()
-		for conn := range s.conns {
-			ctx := conn.Context()
-
-			if update.Username() != "" && (ctx.User == nil || ctx.User.Username() != update.Username()) {
+		for conn, sub := range s.conns {
+			username := update.Username()
+			mailbox := update.Mailbox()
+			if username != "" && (sub.user == "" || sub.user != username) {
 				continue
 			}
-			if update.Mailbox() != "" && (ctx.Mailbox == nil || ctx.Mailbox.Name() != update.Mailbox()) {
+			if mailbox != "" && (sub.mailbox == "" || sub.mailbox != mailbox) {
 				continue
 			}
-			if *conn.silent() {
+			if sub.silent {
 				// If silent is set, do not send message updates
 				if _, ok := res.(*responses.Fetch); ok {
 					continue
 				}
 			}
 
-			conn := conn // Copy conn to a local variable
-			go func() {
-				done := make(chan struct{})
-				conn.Context().Responses <- &response{
-					response: res,
-					done:     done,
-				}
-				<-done
-				sends <- struct{}{}
-			}()
-
-			wait++
+			// Try sending to client.
+			select {
+			case conn.Context().Responses <- buf:
+			default:
+				// Connection's response channel is blocked (busy).  Skipping
+			}
 		}
 		s.locker.Unlock()
 
-		if wait > 0 {
-			go func() {
-				for done := 0; done < wait; done++ {
-					<-sends
-				}
-
-				close(update.Done())
-			}()
-		} else {
-			close(update.Done())
-		}
+		close(update.Done())
 	}
 }
 


### PR DESCRIPTION
I have been using Dovecot's [ImapTest](https://github.com/dovecot/imaptest) program to stress test the server in go-imap using the memory backend.

The memory backend is now more feature complete and a good starting point for new backends.

In the core server code, I fixed some data races and deadlocks.

The Backend updates support was very broken.
