### PR TITLE
commands: Properly handle EOF in Authenticate.Handle

### DIFF
--- a/commands/authenticate.go
+++ b/commands/authenticate.go
@@ -100,9 +100,11 @@ func (cmd *Authenticate) Handle(mechanisms map[string]sasl.Server, conn Authenti
 			return err
 		}
 
-		scanner.Scan()
-		if err := scanner.Err(); err != nil {
-			return err
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return err
+			}
+			return errors.New("unexpected EOF")
 		}
 
 		encoded = scanner.Text()


### PR DESCRIPTION
>scanner.Scan returns false but scanner.Err returns nil in case of EOF.

See https://github.com/foxcpp/maddy/issues/143.