### PR TITLE
close connection on failed write

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -213,6 +213,8 @@ func (c *conn) send() {
 			// Request to send the response
 			if err := c.writeAndFlush(res); err != nil {
 				c.Server().ErrorLog.Println("cannot send response: ", err)
+				c.Close()
+				return
 			}
 		case <-c.loggedOut:
 			return


### PR DESCRIPTION
trying to fix following error:
```
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1797: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1796: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1797: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1796: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1797: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1796: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1797: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1796: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1797: write: broken pipe
Oct 22 15:19:31 speedy imap-tags[27635]: imap/server: 2019/10/22 15:19:31 cannot send response:  write tcp A:143->B:1796: write: broken pipe
```