### PR TITLE
Fix the format of keyword flags

### DIFF
--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -389,15 +389,15 @@ func TestClient_Store(t *testing.T) {
 	done := make(chan error, 1)
 	updates := make(chan *imap.Message, 1)
 	go func() {
-		done <- c.Store(seqset, imap.AddFlags, []interface{}{imap.SeenFlag}, updates)
+		done <- c.Store(seqset, imap.AddFlags, []interface{}{imap.SeenFlag, "foobar"}, updates)
 	}()
 
 	tag, cmd := s.ScanCmd()
-	if cmd != "STORE 2 +FLAGS (\\Seen)" {
-		t.Fatalf("client sent command %v, want %v", cmd, "STORE 2 +FLAGS (\\Seen)")
+	if cmd != "STORE 2 +FLAGS (\\Seen foobar)" {
+		t.Fatalf( "client sent command %v, want %v", cmd, "STORE 2 +FLAGS (\\Seen foobar)")
 	}
 
-	s.WriteString("* 2 FETCH (FLAGS (\\Seen))\r\n")
+	s.WriteString("* 2 FETCH (FLAGS (\\Seen foobar))\r\n")
 	s.WriteString(tag + " OK STORE completed\r\n")
 
 	if err := <-done; err != nil {
@@ -405,7 +405,7 @@ func TestClient_Store(t *testing.T) {
 	}
 
 	msg := <-updates
-	if len(msg.Flags) != 1 || msg.Flags[0] != "\\Seen" {
+	if len(msg.Flags) != 2 || msg.Flags[0] != "\\Seen" || msg.Flags[1] != "foobar" {
 		t.Errorf("Bad message flags: %v", msg.Flags)
 	}
 }
@@ -420,12 +420,12 @@ func TestClient_Store_Silent(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- c.Store(seqset, imap.AddFlags, []interface{}{imap.SeenFlag}, nil)
+		done <- c.Store(seqset, imap.AddFlags, []interface{}{imap.SeenFlag, "foobar"}, nil)
 	}()
 
 	tag, cmd := s.ScanCmd()
-	if cmd != "STORE 2:3 +FLAGS.SILENT (\\Seen)" {
-		t.Fatalf("client sent command %v, want %v", cmd, "STORE 2:3 +FLAGS.SILENT (\\Seen)")
+	if cmd != "STORE 2:3 +FLAGS.SILENT (\\Seen foobar)" {
+		t.Fatalf("client sent command %v, want %v", cmd, "STORE 2:3 +FLAGS.SILENT (\\Seen foobar)")
 	}
 
 	s.WriteString(tag + " OK STORE completed\r\n")
@@ -445,12 +445,12 @@ func TestClient_Store_Uid(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- c.UidStore(seqset, imap.AddFlags, []interface{}{imap.DeletedFlag}, nil)
+		done <- c.UidStore(seqset, imap.AddFlags, []interface{}{imap.DeletedFlag, "foobar"}, nil)
 	}()
 
 	tag, cmd := s.ScanCmd()
-	if cmd != "UID STORE 27:901 +FLAGS.SILENT (\\Deleted)" {
-		t.Fatalf("client sent command %v, want %v", cmd, "UID STORE 27:901 +FLAGS.SILENT (\\Deleted)")
+	if cmd != "UID STORE 27:901 +FLAGS.SILENT (\\Deleted foobar)" {
+		t.Fatalf( "client sent command %v, want %v", cmd, "UID STORE 27:901 +FLAGS.SILENT (\\Deleted foobar)")
 	}
 
 	s.WriteString(tag + " OK STORE completed\r\n")

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -151,8 +151,8 @@ func ExampleClient_Append() {
 	b.WriteString("\r\n")
 	b.WriteString("Hey <3")
 
-	// Append it to INBOX, with a flag
-	flags := []string{imap.FlaggedFlag}
+	// Append it to INBOX, with two flags
+	flags := []string{imap.FlaggedFlag, "foobar"}
 	if err := c.Append("INBOX", flags, time.Now(), &b); err != nil {
 		log.Fatal(err)
 	}

--- a/search.go
+++ b/search.go
@@ -330,7 +330,7 @@ func (c *SearchCriteria) Format() []interface{} {
 		case AnsweredFlag, DeletedFlag, DraftFlag, FlaggedFlag, RecentFlag, SeenFlag:
 			subfields = []interface{}{RawString(strings.ToUpper(strings.TrimPrefix(flag, "\\")))}
 		default:
-			subfields = []interface{}{RawString("KEYWORD"), flag}
+			subfields = []interface{}{RawString("KEYWORD"), RawString(flag)}
 		}
 		fields = append(fields, subfields...)
 	}
@@ -342,7 +342,7 @@ func (c *SearchCriteria) Format() []interface{} {
 		case RecentFlag:
 			subfields = []interface{}{RawString("OLD")}
 		default:
-			subfields = []interface{}{RawString("UNKEYWORD"), flag}
+			subfields = []interface{}{RawString("UNKEYWORD"), RawString(flag)}
 		}
 		fields = append(fields, subfields...)
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -25,7 +25,7 @@ var searchCriteriaTests = []struct {
 		expected: `(1:42 UID 743:938 ` +
 			`SINCE "5-Nov-1984" BEFORE "21-Nov-1997" SENTSINCE "5-Nov-1984" SENTBEFORE "21-Nov-1997" ` +
 			`FROM "root@protonmail.com" BODY "hey there" TEXT "DILLE" ` +
-			`ANSWERED DELETED KEYWORD "cc" UNKEYWORD "microsoft" ` +
+			`ANSWERED DELETED KEYWORD cc UNKEYWORD microsoft ` +
 			`LARGER 4242 SMALLER 4342 ` +
 			`NOT (SENTON "21-Nov-1997" HEADER "Content-Type" "text/csv") ` +
 			`OR (ON "5-Nov-1984" DRAFT FLAGGED UNANSWERED UNDELETED OLD) (UNDRAFT UNFLAGGED UNSEEN))`,


### PR DESCRIPTION
See #324. Please note this does not fully validate the keywords. In particular, it does not check keywords against forbidden characters. Though possible, this would involve bigger changes, and more tests.