### PR TITLE
Support ALL criteria in SEARCH

### DIFF
--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -122,7 +122,8 @@ func (c *Client) search(uid bool, criteria *imap.SearchCriteria) (ids []uint32, 
 // match the searching criteria. When multiple keys are specified, the result is
 // the intersection (AND function) of all the messages that match those keys.
 // Criteria must be UTF-8 encoded. See RFC 3501 section 6.4.4 for a list of
-// searching criteria.
+// searching criteria. When no criteria has been set, all messages in the mailbox
+// will be searched using ALL criteria.
 func (c *Client) Search(criteria *imap.SearchCriteria) (seqNums []uint32, err error) {
 	return c.search(false, criteria)
 }

--- a/search.go
+++ b/search.go
@@ -362,5 +362,10 @@ func (c *SearchCriteria) Format() []interface{} {
 		fields = append(fields, RawString("OR"), or[0].Format(), or[1].Format())
 	}
 
+	// Not a single criteria given, add ALL criteria as fallback
+	if len(fields) == 0 {
+		fields = append(fields, RawString("ALL"))
+	}
+
 	return fields
 }

--- a/search_test.go
+++ b/search_test.go
@@ -65,6 +65,10 @@ var searchCriteriaTests = []struct {
 			}},
 		},
 	},
+	{
+		expected: "(ALL)",
+		criteria: &SearchCriteria{},
+	},
 }
 
 func TestSearchCriteria_Format(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Arnold Bechtoldt <arnold.bechtoldt@inovex.de>

```
criteria := imap.NewSearchCriteria()
c.UidSearch(criteria) // returns: []  Error in IMAP command UID SEARCH: Missing search parameters (0.001 + 0.000 secs).
```


Current behaviour:

```
Z12hwA EXAMINE INBOX
* FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
* OK [PERMANENTFLAGS ()] Read-only mailbox.
* 6 EXISTS
* 6 RECENT
* OK [UNSEEN 1] First unseen.
* OK [UIDVALIDITY 1578248986] UIDs valid
* OK [UIDNEXT 7] Predicted next UID
Z12hwA OK [READ-ONLY] Examine completed (0.001 + 0.000 secs).
hw_TVQ UID SEARCH CHARSET UTF-8
hw_TVQ BAD Error in IMAP command UID SEARCH: Missing search parameters (0.001 + 0.000 secs).
IximMg LOGOUT
* BYE Logging out
IximMg OK Logout completed (0.001 + 0.000 secs).
```