### PR TITLE
Added support for Gmail's X-GM-RAW search fields

### DIFF
--- a/search_test.go
+++ b/search_test.go
@@ -28,7 +28,8 @@ var searchCriteriaTests = []struct {
 			`ANSWERED DELETED KEYWORD cc UNKEYWORD microsoft ` +
 			`LARGER 4242 SMALLER 4342 ` +
 			`NOT (SENTON "21-Nov-1997" HEADER "Content-Type" "text/csv") ` +
-			`OR (ON "5-Nov-1984" DRAFT FLAGGED UNANSWERED UNDELETED OLD) (UNDRAFT UNFLAGGED UNSEEN))`,
+			`OR (ON "5-Nov-1984" DRAFT FLAGGED UNANSWERED UNDELETED OLD) (UNDRAFT UNFLAGGED UNSEEN) ` +
+			`X-GM-RAW "has:attachment")`,
 		criteria: &SearchCriteria{
 			SeqNum:     searchSeqSet1,
 			Uid:        searchSeqSet2,
@@ -63,6 +64,7 @@ var searchCriteriaTests = []struct {
 					WithoutFlags: []string{DraftFlag, FlaggedFlag, SeenFlag},
 				},
 			}},
+			XGMRaw: []string{"has:attachment"},
 		},
 	},
 	{


### PR DESCRIPTION
Hi there!

This is my first contribution to this library and I will say it's quite powerful!

I dug around this morning looking for ways to add arbitrary raw attributes to the search queries and was unable to do so. After further consideration it seems the best way would be to add native X-GM-RAW support to this library!

The specification can be found here https://developers.google.com/gmail/imap/imap-extensions but simply put, we can add a X-GM-RAW attribute to the search query.

I find this necessary to my use case and I believe others may also find it useful. I've added the correct logic and tests.

Thanks!