### PR TITLE
Neopallium server-side fixes and improvements

### DIFF
--- a/server/cmd_auth.go
+++ b/server/cmd_auth.go
@@ -41,6 +41,9 @@ func (cmd *Select) Handle(conn Conn) error {
 
 	ctx.Mailbox = mbox
 	ctx.MailboxReadOnly = cmd.ReadOnly || status.ReadOnly
+	// Update Mbox listener
+	s := conn.Server()
+	s.updateMboxListener(conn, ctx.User.Username(), mbox.Name())
 
 	res := &responses.Select{Mailbox: status}
 	if err := conn.WriteResp(res); err != nil {

--- a/server/cmd_auth_test.go
+++ b/server/cmd_auth_test.go
@@ -397,6 +397,18 @@ func TestList_Subscribed(t *testing.T) {
 	}
 }
 
+func TestTLS_AlreadyAuthenticated(t *testing.T) {
+	s, c, scanner := testServerAuthenticated(t)
+	defer s.Close()
+	defer c.Close()
+
+	io.WriteString(c, "a001 STARTTLS\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
+		t.Fatal("Invalid status response:", scanner.Text())
+	}
+}
+
 func TestList_NotAuthenticated(t *testing.T) {
 	s, c, scanner := testServerGreeted(t)
 	defer s.Close()

--- a/server/cmd_noauth.go
+++ b/server/cmd_noauth.go
@@ -102,6 +102,9 @@ func (cmd *Login) Handle(conn Conn) error {
 
 	ctx.State = imap.AuthenticatedState
 	ctx.User = user
+	// Update Mbox listener
+	s := conn.Server()
+	s.updateMboxListener(conn, user.Username(), "")
 	return afterAuthStatus(conn)
 }
 

--- a/server/cmd_noauth_test.go
+++ b/server/cmd_noauth_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"io"
 	"net"
+	"log"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/emersion/go-imap/internal"
 	"github.com/emersion/go-imap/server"
@@ -120,6 +122,41 @@ func TestLogin_AlreadyAuthenticated(t *testing.T) {
 	scanner.Scan()
 	if !strings.HasPrefix(scanner.Text(), "a001 NO ") {
 		t.Fatal("Bad status response:", scanner.Text())
+	}
+}
+
+func TestLogin_AutoLogout(t *testing.T) {
+	s, c, scanner := testServerGreeted(t)
+	s.MinAutoLogout = 1 * time.Second
+	defer s.Close()
+	defer c.Close()
+	s.AutoLogout = 2 * time.Second
+
+	// Login
+	io.WriteString(c, "a001 LOGIN username password\r\n")
+	scanner.Scan()
+	if !strings.HasPrefix(scanner.Text(), "a001 OK ") {
+		t.Fatal("Bad status response:", scanner.Text())
+	}
+
+	//// Test for auto logout
+
+	// background goroutine to wait for auto logout
+	done := make(chan string)
+	go (func() {
+		defer close(done)
+		if scanner.Scan() {
+			log.Println("Got response: ", scanner.Text())
+		} else {
+			log.Println("Got error: ", scanner.Err())
+		}
+	})()
+
+	select {
+	case <-done:
+		// Auto logout
+	case <-time.After(10 * time.Second):
+		t.Fatal("AutoLogout Failed.")
 	}
 }
 

--- a/server/cmd_selected.go
+++ b/server/cmd_selected.go
@@ -51,6 +51,9 @@ func (cmd *Close) Handle(conn Conn) error {
 	mailbox := ctx.Mailbox
 	ctx.Mailbox = nil
 	ctx.MailboxReadOnly = false
+	// Update Mbox listener
+	s := conn.Server()
+	s.updateMboxListener(conn, ctx.User.Username(), "")
 
 	// No need to send expunge updates here, since the mailbox is already unselected
 	return mailbox.Expunge()
@@ -239,10 +242,14 @@ func (cmd *Store) handle(uid bool, conn Conn) error {
 
 	// If the backend supports message updates, this will prevent this connection
 	// from receiving them
-	// TODO: find a better way to do this, without conn.silent
-	*conn.silent() = silent
+	srv := conn.Server()
+	if silent {
+		srv.silentMboxListener(conn, true)
+	}
 	err = ctx.Mailbox.UpdateMessagesFlags(uid, cmd.SeqSet, op, flags)
-	*conn.silent() = false
+	if silent {
+		srv.silentMboxListener(conn, false)
+	}
 	if err != nil {
 		return err
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -136,8 +136,8 @@ func (c *conn) setDeadline() {
 	}
 
 	dur := c.s.AutoLogout
-	if dur < MinAutoLogout {
-		dur = MinAutoLogout
+	if dur < c.s.MinAutoLogout {
+		dur = c.s.MinAutoLogout
 	}
 	t := time.Now().Add(dur)
 

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@
 package server
 
 import (
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -87,11 +88,17 @@ func ErrNoStatusResp() error {
 	return &errStatusResp{nil}
 }
 
+type mboxListener struct {
+	user    string
+	mailbox string
+	silent  bool
+}
+
 // An IMAP server.
 type Server struct {
 	locker    sync.Mutex
 	listeners map[net.Listener]struct{}
-	conns     map[Conn]struct{}
+	conns     map[Conn]*mboxListener
 
 	commands   map[string]HandlerFactory
 	auths      map[string]SASLServerFactory
@@ -127,7 +134,7 @@ type Server struct {
 func New(bkd backend.Backend) *Server {
 	s := &Server{
 		listeners: make(map[net.Listener]struct{}),
-		conns:     make(map[Conn]struct{}),
+		conns:     make(map[Conn]*mboxListener),
 		Backend:   bkd,
 		ErrorLog:  log.New(os.Stderr, "imap/server: ", log.LstdFlags),
 	}
@@ -268,7 +275,7 @@ func (s *Server) ListenAndServeTLS() error {
 
 func (s *Server) serveConn(conn Conn) error {
 	s.locker.Lock()
-	s.conns[conn] = struct{}{}
+	s.conns[conn] = &mboxListener{}
 	s.locker.Unlock()
 
 	defer func() {
@@ -281,6 +288,23 @@ func (s *Server) serveConn(conn Conn) error {
 	return conn.serve(conn)
 }
 
+func (s *Server) updateMboxListener(conn Conn, user string, mailbox string) {
+	s.locker.Lock()
+	if sub, ok := s.conns[conn]; ok {
+		sub.user = user
+		sub.mailbox = mailbox
+	}
+	s.locker.Unlock()
+}
+
+func (s *Server) silentMboxListener(conn Conn, silent bool) {
+	s.locker.Lock()
+	if sub, ok := s.conns[conn]; ok {
+		sub.silent = silent
+	}
+	s.locker.Unlock()
+}
+
 // Command gets a command handler factory for the provided command name.
 func (s *Server) Command(name string) HandlerFactory {
 	// Extensions can override builtin commands
@@ -291,6 +315,24 @@ func (s *Server) Command(name string) HandlerFactory {
 	}
 
 	return s.commands[name]
+}
+
+type bufResp struct {
+	bytes.Buffer
+}
+
+func (br *bufResp) WriteTo(w *imap.Writer) error {
+	_, err := w.Write(br.Buffer.Bytes())
+	return err
+}
+
+func bufferResp(res imap.WriterTo) (imap.WriterTo, error) {
+	buf := bufResp{}
+	bufWriter := imap.NewWriter(&buf)
+	if err := res.WriteTo(bufWriter); err != nil {
+		return nil, err
+	}
+	return &buf, nil
 }
 
 func (s *Server) listenUpdates() {
@@ -321,52 +363,40 @@ func (s *Server) listenUpdates() {
 		if res == nil {
 			continue
 		}
+		// Write response to buffer, so we can send it to multiple connections.
+		buf, err := bufferResp(res)
+		if err != nil {
+			s.ErrorLog.Printf("Failed to buffer update: %s\n", err)
+			continue
+		}
 
-		sends := make(chan struct{})
-		wait := 0
 		s.locker.Lock()
-		for conn := range s.conns {
-			ctx := conn.Context()
-
-			if update.Username() != "" && (ctx.User == nil || ctx.User.Username() != update.Username()) {
+		for conn, sub := range s.conns {
+			username := update.Username()
+			mailbox := update.Mailbox()
+			if username != "" && (sub.user == "" || sub.user != username) {
 				continue
 			}
-			if update.Mailbox() != "" && (ctx.Mailbox == nil || ctx.Mailbox.Name() != update.Mailbox()) {
+			if mailbox != "" && (sub.mailbox == "" || sub.mailbox != mailbox) {
 				continue
 			}
-			if *conn.silent() {
+			if sub.silent {
 				// If silent is set, do not send message updates
 				if _, ok := res.(*responses.Fetch); ok {
 					continue
 				}
 			}
 
-			conn := conn // Copy conn to a local variable
-			go func() {
-				done := make(chan struct{})
-				conn.Context().Responses <- &response{
-					response: res,
-					done:     done,
-				}
-				<-done
-				sends <- struct{}{}
-			}()
-
-			wait++
+			// Try sending to client.
+			select {
+			case conn.Context().Responses <- buf:
+			default:
+				// Connection's response channel is blocked (busy).  Skipping
+			}
 		}
 		s.locker.Unlock()
 
-		if wait > 0 {
-			go func() {
-				for done := 0; done < wait; done++ {
-					<-sends
-				}
-
-				close(update.Done())
-			}()
-		} else {
-			close(update.Done())
-		}
+		close(update.Done())
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -18,9 +18,6 @@ import (
 	"github.com/emersion/go-sasl"
 )
 
-// The minimum autologout duration defined in RFC 3501 section 5.4.
-const MinAutoLogout = 30 * time.Minute
-
 // A command handler.
 type Handler interface {
 	imap.Parser
@@ -116,6 +113,8 @@ type Server struct {
 	// automatically, set this to zero. The duration MUST be at least
 	// MinAutoLogout (as stated in RFC 3501 section 5.4).
 	AutoLogout time.Duration
+	// MinAutoLogout can be overridden, but RFC 3501 says it MUST be at least 30 minutes.
+	MinAutoLogout time.Duration
 	// Allow authentication over unencrypted connections.
 	AllowInsecureAuth bool
 	// An io.Writer to which all network activity will be mirrored.
@@ -137,6 +136,8 @@ func New(bkd backend.Backend) *Server {
 		conns:     make(map[Conn]*mboxListener),
 		Backend:   bkd,
 		ErrorLog:  log.New(os.Stderr, "imap/server: ", log.LstdFlags),
+		// The minimum autologout duration defined in RFC 3501 section 5.4.
+		MinAutoLogout: 30 * time.Minute,
 	}
 
 	s.auths = map[string]SASLServerFactory{


### PR DESCRIPTION
This is https://github.com/emersion/go-imap/pull/300 rebased against master.

The AutoLogout test has a race:

```
==================
WARNING: DATA RACE
Write at 0x00c000172800 by goroutine 51:
  github.com/emersion/go-imap/server_test.TestLogin_AutoLogout()
      /home/simon/src/go-imap/server/cmd_noauth_test.go:133 +0x134
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:909 +0x199

Previous read at 0x00c000172800 by goroutine 46:
  github.com/emersion/go-imap/server.(*conn).setDeadline()
      /home/simon/src/go-imap/server/conn.go:134 +0x6a
  github.com/emersion/go-imap/server.(*conn).greet()
      /home/simon/src/go-imap/server/conn.go:151 +0x3f7
  github.com/emersion/go-imap/server.(*conn).serve()
      /home/simon/src/go-imap/server/conn.go:285 +0x138
  github.com/emersion/go-imap/server.(*Server).serveConn()
      /home/simon/src/go-imap/server/server.go:289 +0x1c1

Goroutine 51 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:198 +0x223

Goroutine 46 (running) created at:
  github.com/emersion/go-imap/server.(*Server).Serve()
      /home/simon/src/go-imap/server/server.go:237 +0x256
==================
```

Also, the AutoLogout test consistently takes 2 seconds. Not sure how to improve that since it's time-related.

cc @Neopallium 