### PR TITLE
server: Add Mailbox.Close, make ListMailboxes return MailboxInfo

### DIFF
--- a/backend/mailbox.go
+++ b/backend/mailbox.go
@@ -12,6 +12,9 @@ type Mailbox interface {
 	// Name returns this mailbox name.
 	Name() string
 
+	// Closes the mailbox.
+	Close() error
+
 	// Info returns this mailbox info.
 	Info() (*imap.MailboxInfo, error)
 

--- a/backend/memory/mailbox.go
+++ b/backend/memory/mailbox.go
@@ -241,3 +241,7 @@ func (mbox *Mailbox) Expunge() error {
 
 	return nil
 }
+
+func (mbox *Mailbox) Close() error {
+	return nil
+}

--- a/backend/memory/user.go
+++ b/backend/memory/user.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"errors"
 
+	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/backend"
 )
 
@@ -16,13 +17,17 @@ func (u *User) Username() string {
 	return u.username
 }
 
-func (u *User) ListMailboxes(subscribed bool) (mailboxes []backend.Mailbox, err error) {
+func (u *User) ListMailboxes(subscribed bool) (info []imap.MailboxInfo, err error) {
 	for _, mailbox := range u.mailboxes {
 		if subscribed && !mailbox.Subscribed {
 			continue
 		}
 
-		mailboxes = append(mailboxes, mailbox)
+		mboxInfo, err := mailbox.Info()
+		if err != nil {
+			return nil, err
+		}
+		info = append(info, *mboxInfo)
 	}
 	return
 }

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,6 +1,10 @@
 package backend
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/emersion/go-imap"
+)
 
 var (
 	// ErrNoSuchMailbox is returned by User.GetMailbox, User.DeleteMailbox and
@@ -18,9 +22,9 @@ type User interface {
 	// Username returns this user's username.
 	Username() string
 
-	// ListMailboxes returns a list of mailboxes belonging to this user. If
-	// subscribed is set to true, only returns subscribed mailboxes.
-	ListMailboxes(subscribed bool) ([]Mailbox, error)
+	// ListMailboxes returns information about mailboxes belonging to this
+	// user. If subscribed is set to true, only returns subscribed mailboxes.
+	ListMailboxes(subscribed bool) ([]imap.MailboxInfo, error)
 
 	// GetMailbox returns a mailbox. If it doesn't exist, it returns
 	// ErrNoSuchMailbox.

--- a/server/cmd_auth.go
+++ b/server/cmd_auth.go
@@ -166,6 +166,11 @@ func (cmd *List) Handle(conn Conn) error {
 		close(ch)
 		return err
 	}
+	defer func() {
+		for _, mbox := range mailboxes {
+			closeMailbox(mbox)
+		}
+	}()
 
 	for _, mbox := range mailboxes {
 		info, err := mbox.Info()


### PR DESCRIPTION
~~This change is backward compatible with v1.~~

go-imap-unselect needs an update to avoid 'leaking' mailboxes, I propose to merge it into go-imap along the way per #322.

Closes #337.