### PR TITLE
Merge support for COMPRESS extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ includes:
 * [CHILDREN](https://tools.ietf.org/html/rfc3348)
 * [UNSELECT](https://tools.ietf.org/html/rfc3691)
 * [APPENDLIMIT](https://tools.ietf.org/html/rfc7889)
+* [COMPRESS](https://tools.ietf.org/html/rfc4978)
 
 Support for other extensions is provided via separate packages. See below.
 
@@ -146,7 +147,6 @@ Commands defined in IMAP extensions are available in other packages. See [the
 wiki](https://github.com/emersion/go-imap/wiki/Using-extensions#using-client-extensions)
 to learn how to use them.
 
-* [COMPRESS](https://github.com/emersion/go-imap-compress)
 * [ENABLE](https://github.com/emersion/go-imap-enable)
 * [ID](https://github.com/ProtonMail/go-imap-id)
 * [IDLE](https://github.com/emersion/go-imap-idle)

--- a/client/client.go
+++ b/client/client.go
@@ -66,9 +66,10 @@ type Client struct {
 	isTLS      bool
 	serverName string
 
-	loggedOut chan struct{}
-	continues chan<- bool
-	upgrading bool
+	loggedOut    chan struct{}
+	continues    chan<- bool
+	upgrading    bool
+	isCompressed bool
 
 	handlers       []responses.Handler
 	handlersLocker sync.Mutex

--- a/commands/compress.go
+++ b/commands/compress.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"errors"
+
+	"github.com/emersion/go-imap"
+)
+
+// A COMPRESS command.
+type Compress struct {
+	// Name of the compression mechanism.
+	Mechanism string
+}
+
+func (cmd *Compress) Command() *imap.Command {
+	return &imap.Command{
+		Name:      "COMPRESS",
+		Arguments: []interface{}{cmd.Mechanism},
+	}
+}
+
+func (cmd *Compress) Parse(fields []interface{}) (err error) {
+	if len(fields) < 1 {
+		return errors.New("No enough arguments")
+	}
+
+	var ok bool
+	if cmd.Mechanism, ok = fields[0].(string); !ok {
+		return errors.New("Compression mechanism name must be a string")
+	}
+
+	return nil
+}

--- a/deflate.go
+++ b/deflate.go
@@ -1,0 +1,17 @@
+package imap
+
+// A CompressUnsuppportedError is returned by Client.Compress when the provided
+// compression mechanism is not supported.
+type CompressUnsupportedError struct {
+	Mechanism string
+}
+
+func (err CompressUnsupportedError) Error() string {
+	return "COMPRESS mechanism " + err.Mechanism + " not supported"
+}
+
+// Compression algorithms for use with COMPRESS extension (RFC 4978).
+const (
+	// The DEFLATE algorithm, defined in RFC 1951.
+	CompressDeflate = "DEFLATE"
+)

--- a/internal/deflate.go
+++ b/internal/deflate.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"compress/flate"
+	"io"
+	"net"
+)
+
+type deflateConn struct {
+	net.Conn
+
+	r io.ReadCloser
+	w *flate.Writer
+}
+
+func (c *deflateConn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}
+
+func (c *deflateConn) Write(b []byte) (int, error) {
+	return c.w.Write(b)
+}
+
+type flusher interface {
+	Flush() error
+}
+
+func (c *deflateConn) Flush() error {
+	if f, ok := c.Conn.(flusher); ok {
+		if err := f.Flush(); err != nil {
+			return err
+		}
+	}
+
+	return c.w.Flush()
+}
+
+func (c *deflateConn) Close() error {
+	if err := c.r.Close(); err != nil {
+		return err
+	}
+
+	if err := c.w.Close(); err != nil {
+		return err
+	}
+
+	return c.Conn.Close()
+}
+
+func CreateDeflateConn(c net.Conn, level int) (net.Conn, error) {
+	r := flate.NewReader(c)
+	w, err := flate.NewWriter(c, level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deflateConn{
+		Conn: c,
+		r:    r,
+		w:    w,
+	}, nil
+}

--- a/server/conn.go
+++ b/server/conn.go
@@ -163,7 +163,7 @@ func (c *conn) Close() error {
 }
 
 func (c *conn) Capabilities() []string {
-	caps := []string{"IMAP4rev1", "LITERAL+", "SASL-IR", "CHILDREN", "UNSELECT"}
+	caps := []string{"IMAP4rev1", "LITERAL+", "SASL-IR", "CHILDREN", "UNSELECT", "COMPRESS=DEFLATE"}
 
 	appendLimitSet := false
 	if c.ctx.State == imap.AuthenticatedState {

--- a/server/server.go
+++ b/server/server.go
@@ -187,6 +187,7 @@ func New(bkd backend.Backend) *Server {
 		"UID":     func() Handler { return &Uid{} },
 
 		"UNSELECT": func() Handler { return &Unselect{} },
+		"COMPRESS": func() Handler { return &Compress{} },
 	}
 
 	return s


### PR DESCRIPTION
First round of changes for #322.

- [x] APPENDLIMIT
- [x] COMPRESS
- [x] ENABLE
- [ ] ~~ID~~
- [x] SPECIAL-USE
- [x] UNSELECT
- [x] [CHILDREN](https://github.com/foxcpp/go-imap-sql/tree/master/children)
- [ ] [I18NLEVEL](https://github.com/foxcpp/go-imap-i18nlevel) (perhaps level 1 only?)

This PR does not include server-side change to the UNSELECT command required by #341 (needs rebase after #341 gets merged)