### PR TITLE
Add MailboxInfoUpdate

### DIFF
--- a/backend/updates.go
+++ b/backend/updates.go
@@ -60,6 +60,12 @@ type MailboxUpdate struct {
 	*imap.MailboxStatus
 }
 
+// MailboxInfoUpdate is a maiblox info update.
+type MailboxInfoUpdate struct {
+	Update
+	*imap.MailboxInfo
+}
+
 // MessageUpdate is a message update.
 type MessageUpdate struct {
 	Update

--- a/server/server.go
+++ b/server/server.go
@@ -303,6 +303,12 @@ func (s *Server) listenUpdates() {
 			res = update.StatusResp
 		case *backend.MailboxUpdate:
 			res = &responses.Select{Mailbox: update.MailboxStatus}
+		case *backend.MailboxInfoUpdate:
+			ch := make(chan *imap.MailboxInfo, 1)
+			ch <- update.MailboxInfo
+			close(ch)
+
+			res = &responses.List{Mailboxes: ch}
 		case *backend.MessageUpdate:
 			ch := make(chan *imap.Message, 1)
 			ch <- update.Message


### PR DESCRIPTION
By RFC any untagged response can be send from server anytime. INFO is useful to notify client that new mailbox was created on server. This adds only support for this update but for v2 would be good to have ability to send update of any kind. Probably `Update` interface could contain function to generate response and even if go-imap do not support some update any app could create add without need to change `listenUpdates` in go-imap server.