### PR TITLE
readme: use variable instead of mbox.Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func main() {
 	// Get the last 4 messages
 	from := uint32(1)
 	to := mbox.Messages
-	if mbox.Messages > 3 {
+	if to > 3 {
 		// We're using unsigned integers here, only substract if the result is > 0
 		from = mbox.Messages - 3
 	}


### PR DESCRIPTION
It's assigning mbox.Messages to `to` but then in the if condition is not used.