### PR TITLE
Support NIL heirarchy delimiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.13
 require (
 	github.com/emersion/go-message v0.11.1
 	github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b
-	github.com/stretchr/testify v1.3.0
 	golang.org/x/text v0.3.2
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.13
 require (
 	github.com/emersion/go-message v0.11.1
 	github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/text v0.3.2
 )

--- a/mailbox.go
+++ b/mailbox.go
@@ -43,8 +43,7 @@ type MailboxInfo struct {
 	// The mailbox attributes.
 	Attributes []string
 	// The server's path separator.
-	Delimiter       string
-	HasNILDelimiter bool
+	Delimiter string
 	// The mailbox name.
 	Name string
 }
@@ -66,7 +65,7 @@ func (info *MailboxInfo) Parse(fields []interface{}) error {
 		if fields[1] != nil {
 			return errors.New("Mailbox delimiter must be a string")
 		}
-		info.HasNILDelimiter = true
+		info.Delimiter = ""
 	}
 
 	if name, err := ParseString(fields[2]); err != nil {
@@ -92,7 +91,7 @@ func (info *MailboxInfo) Format() []interface{} {
 	// a nil field (so that it's later converted to an unquoted NIL atom).
 	var del interface{}
 
-	if !info.HasNILDelimiter {
+	if info.Delimiter != "" {
 		del = info.Delimiter
 	}
 
@@ -137,12 +136,12 @@ func (info *MailboxInfo) match(name, pattern string) bool {
 func (info *MailboxInfo) Match(reference, pattern string) bool {
 	name := info.Name
 
-	if !info.HasNILDelimiter && strings.HasPrefix(pattern, info.Delimiter) {
+	if info.Delimiter != "" && strings.HasPrefix(pattern, info.Delimiter) {
 		reference = ""
 		pattern = strings.TrimPrefix(pattern, info.Delimiter)
 	}
 	if reference != "" {
-		if !info.HasNILDelimiter && !strings.HasSuffix(reference, info.Delimiter) {
+		if info.Delimiter != "" && !strings.HasSuffix(reference, info.Delimiter) {
 			reference += info.Delimiter
 		}
 		if !strings.HasPrefix(name, reference) {

--- a/read.go
+++ b/read.go
@@ -217,9 +217,10 @@ func (r *Reader) ReadAtom() (interface{}, error) {
 
 	r.UnreadRune()
 
-	if atom == "NIL" {
+	if atom == nilAtom {
 		return nil, nil
 	}
+
 	return atom, nil
 }
 

--- a/responses/list_test.go
+++ b/responses/list_test.go
@@ -5,32 +5,40 @@ import (
 	"testing"
 
 	"github.com/emersion/go-imap"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestListSlashDelimiter(t *testing.T) {
 	mbox := &imap.MailboxInfo{}
 
-	require.NoError(t, mbox.Parse([]interface{}{
+	if err := mbox.Parse([]interface{}{
 		[]interface{}{"\\Unseen"},
 		"/",
 		"INBOX",
-	}))
+	}); err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 
-	assert.Equal(t, `* LIST (\Unseen) "/" INBOX`+"\r\n", getListResponse(t, mbox))
+	if response := getListResponse(t, mbox); response != `* LIST (\Unseen) "/" INBOX`+"\r\n" {
+		t.Error("Unexpected response:", response)
+	}
 }
 
 func TestListNILDelimiter(t *testing.T) {
 	mbox := &imap.MailboxInfo{}
 
-	require.NoError(t, mbox.Parse([]interface{}{
+	if err := mbox.Parse([]interface{}{
 		[]interface{}{"\\Unseen"},
 		nil,
 		"INBOX",
-	}))
+	}); err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 
-	assert.Equal(t, `* LIST (\Unseen) NIL INBOX`+"\r\n", getListResponse(t, mbox))
+	if response := getListResponse(t, mbox); response != `* LIST (\Unseen) NIL INBOX`+"\r\n" {
+		t.Error("Unexpected response:", response)
+	}
 }
 
 func newListResponse(mbox *imap.MailboxInfo) (l *List) {
@@ -48,7 +56,10 @@ func getListResponse(t *testing.T, mbox *imap.MailboxInfo) string {
 	b := &bytes.Buffer{}
 	w := imap.NewWriter(b)
 
-	require.NoError(t, newListResponse(mbox).WriteTo(w))
+	if err := newListResponse(mbox).WriteTo(w); err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 
 	return b.String()
 }

--- a/responses/list_test.go
+++ b/responses/list_test.go
@@ -1,0 +1,54 @@
+package responses
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/emersion/go-imap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSlashDelimiter(t *testing.T) {
+	mbox := &imap.MailboxInfo{}
+
+	require.NoError(t, mbox.Parse([]interface{}{
+		[]interface{}{"\\Unseen"},
+		"/",
+		"INBOX",
+	}))
+
+	assert.Equal(t, `* LIST (\Unseen) "/" INBOX`+"\r\n", getListResponse(t, mbox))
+}
+
+func TestListNILDelimiter(t *testing.T) {
+	mbox := &imap.MailboxInfo{}
+
+	require.NoError(t, mbox.Parse([]interface{}{
+		[]interface{}{"\\Unseen"},
+		nil,
+		"INBOX",
+	}))
+
+	assert.Equal(t, `* LIST (\Unseen) NIL INBOX`+"\r\n", getListResponse(t, mbox))
+}
+
+func newListResponse(mbox *imap.MailboxInfo) (l *List) {
+	l = &List{Mailboxes: make(chan *imap.MailboxInfo)}
+
+	go func() {
+		l.Mailboxes <- mbox
+		close(l.Mailboxes)
+	}()
+
+	return
+}
+
+func getListResponse(t *testing.T, mbox *imap.MailboxInfo) string {
+	b := &bytes.Buffer{}
+	w := imap.NewWriter(b)
+
+	require.NoError(t, newListResponse(mbox).WriteTo(w))
+
+	return b.String()
+}


### PR DESCRIPTION
This fixes #329.

In order to make this a non-breaking change I introduce a boolean to indicate whether the delimiter is NIL or not.

~~Also I hope it's okay to include testify. If not, I'll switch to using standard lib.~~ removed testify