### PR TITLE
Fix #310: Possible MailboxStatus race condition

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -313,7 +313,7 @@ func (c *Client) State() imap.ConnState {
 func (c *Client) Mailbox() *imap.MailboxStatus {
 	// c.Mailbox fields are not supposed to change, so we can return the pointer.
 	c.locker.Lock()
-	mbox := c.mailbox
+	mbox := c.mailbox.DeepCopy()
 	c.locker.Unlock()
 	return mbox
 }

--- a/mailbox.go
+++ b/mailbox.go
@@ -262,6 +262,26 @@ func (status *MailboxStatus) Format() []interface{} {
 	return fields
 }
 
+func (status *MailboxStatus) DeepCopy() *MailboxStatus {
+	copy := MailboxStatus{}
+	copy.Name = status.Name
+	copy.ReadOnly = status.ReadOnly
+	copy.Items = map[StatusItem]interface{}{}
+	for index, element := range status.Items {
+		copy.Items[index] = element
+	}
+
+	copy.Flags = append([]string(nil), status.Flags...)
+	copy.PermanentFlags = append([]string(nil), status.PermanentFlags...)
+	copy.UnseenSeqNum = status.UnseenSeqNum
+	copy.Messages = status.Messages
+	copy.Recent = status.Recent
+	copy.Unseen = status.Unseen
+	copy.UidNext = status.UidNext
+	copy.UidValidity = status.UidValidity
+
+	return &copy
+}
 func FormatMailboxName(name string) interface{} {
 	// Some e-mails servers don't handle quoted INBOX names correctly so we special-case it.
 	if strings.EqualFold(name, "INBOX") {

--- a/mailbox_test.go
+++ b/mailbox_test.go
@@ -189,3 +189,48 @@ func TestMailboxStatus_Format(t *testing.T) {
 		}
 	}
 }
+
+func TestMailboxStatus_DeepCopy(t *testing.T) {
+	source := imap.NewMailboxStatus("INBOX", []imap.StatusItem{imap.StatusUidNext})
+	source.ReadOnly = true
+	source.Flags = []string{imap.AnsweredFlag, imap.FlaggedFlag}
+	source.PermanentFlags = []string{imap.AnsweredFlag}
+	source.UnseenSeqNum = 1
+	source.Messages = 42
+	source.Recent = 5
+	source.Unseen = 10
+	source.UidNext = 43
+	source.UidValidity = 1
+
+	copy := source.DeepCopy()
+	if !reflect.DeepEqual(source, copy) {
+		t.Errorf("deepCopy() didn't produce an exact copy for %T: got \n%+v\nbut expected \n%+v", source, copy, source)
+	}
+
+	copy.Name = "Trash"
+	copy.Items[imap.StatusUidNext] = 10
+	copy.ReadOnly = false
+	copy.Flags[0] = imap.DeletedFlag
+	copy.PermanentFlags[0] = imap.DeletedFlag
+	copy.UnseenSeqNum = 2
+	copy.Messages = 43
+	copy.Recent = 6
+	copy.Unseen = 11
+	copy.UidNext = 44
+	copy.UidValidity = 2
+
+	if source.Name == copy.Name ||
+		reflect.DeepEqual(source.Items, copy.Items) ||
+		source.ReadOnly == copy.ReadOnly ||
+		&(source.ItemsLocker) == &(copy.ItemsLocker) ||
+		reflect.DeepEqual(source.Flags, copy.Flags) ||
+		reflect.DeepEqual(source.PermanentFlags, copy.PermanentFlags) ||
+		source.UnseenSeqNum == copy.UnseenSeqNum ||
+		source.Messages == copy.Messages ||
+		source.Recent == copy.Recent ||
+		source.Unseen == copy.Unseen ||
+		source.UidNext == copy.UidNext ||
+		source.UidValidity == copy.UidValidity {
+		t.Errorf("Expected all fields to be different, got source: %+v, copy: %+v", source, copy)
+	}
+}


### PR DESCRIPTION
Hey! I tried to follow [@emersion's advice](https://github.com/emersion/go-imap/issues/310#issuecomment-563174474) and addressed #310 by copying the internal `MailboxStatus` before returning its pointer.

This change can introduce breaking behavior (e.g. a library user was modifying `MailboxStatus` instance returned from `Mailbox()`) but that behavior shouldn't be allowed in the first place.