### PR TITLE
server: rewrite misleading comment about Enable and EnableAuth usage

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -398,17 +398,13 @@ func (s *Server) Close() error {
 }
 
 // Enable some IMAP extensions on this server.
-//
-// This function should not be called directly, it must only be used by
-// libraries implementing extensions of the IMAP protocol.
+// Wiki entry: https://github.com/emersion/go-imap/wiki/Using-extensions
 func (s *Server) Enable(extensions ...Extension) {
 	s.extensions = append(s.extensions, extensions...)
 }
 
 // Enable an authentication mechanism on this server.
-//
-// This function should not be called directly, it must only be used by
-// libraries implementing extensions of the IMAP protocol.
+// Wiki entry: https://github.com/emersion/go-imap/wiki/Using-authentication-mechanisms
 func (s *Server) EnableAuth(name string, f SASLServerFactory) {
 	s.auths[name] = f
 }


### PR DESCRIPTION
After asking in the IRC about the comments above the Enable and EnableAuth methods, I was told that the comment was probably wrong.

This PR replaces them with links to the wiki pages