### PR TITLE
imap: lower some fields + content disposition keys

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -593,6 +593,36 @@ func TestBodyStructure_Parse(t *testing.T) {
 	}
 }
 
+func TestBodyStructure_Parse_uppercase(t *testing.T) {
+	fields := []interface{}{
+		"APPLICATION", "PDF", []interface{}{"NAME", "Document.pdf"}, nil, nil,
+		"BASE64", RawString("4242"), nil,
+		[]interface{}{"ATTACHMENT", []interface{}{"FILENAME", "Document.pdf"}},
+		nil, nil,
+	}
+
+	expected := &BodyStructure{
+		MIMEType:          "application",
+		MIMESubType:       "pdf",
+		Params:            map[string]string{"name": "Document.pdf"},
+		Encoding:          "base64",
+		Size:              4242,
+		Extended:          true,
+		MD5:               "",
+		Disposition:       "attachment",
+		DispositionParams: map[string]string{"filename": "Document.pdf"},
+		Language:          nil,
+		Location:          []string{},
+	}
+
+	bs := &BodyStructure{}
+	if err := bs.Parse(fields); err != nil {
+		t.Errorf("Cannot parse: %v", err)
+	} else if !reflect.DeepEqual(bs, expected) {
+		t.Errorf("Invalid body structure: got \n%+v\n but expected \n%+v", bs, expected)
+	}
+}
+
 func TestBodyStructure_Format(t *testing.T) {
 	for i, test := range bodyStructureTests {
 		fields := test.bodyStructure.Format()


### PR DESCRIPTION
Regarding #383

`TestBodyStructure_Format` does not pass right now because the BodyStructure contains lowercased values of the input string. So when it's formatted, its field list does not match the input.

I could:
1. Move the case out of `bodyStructureTests` into its own test function that does the equivalent of `TestBodyStructure_Parse` on that one case.
2. Add an optional member to the `bodyStructureTests` element struct type to allow overriding the expected value instead of `formatFields(test.fields)`.

The first option seems less freaky. I thought I'd ask in case you have better ideas or preferences.