### PR TITLE
return empty reader instead of nil when BODY is found but server returns nil

### DIFF
--- a/message.go
+++ b/message.go
@@ -337,6 +337,10 @@ func (m *Message) GetBody(section *BodySectionName) Literal {
 
 	for s, body := range m.Body {
 		if section.Equal(s) {
+			if body == nil {
+				// Server can return nil, we need to treat as empty string per RFC 3501
+				body = bytes.NewReader(nil)
+			}
 			return body
 		}
 	}


### PR DESCRIPTION
Server can return nil for a body part, when it's empty but still there. RFC3501 says clients should treat this same as empty string. This patch implements that behavior.