### PR TITLE
Message chan not closed

### DIFF
--- a/responses/fetch.go
+++ b/responses/fetch.go
@@ -36,12 +36,12 @@ func (r *Fetch) Handle(resp imap.Resp) error {
 }
 
 func (r *Fetch) WriteTo(w *imap.Writer) error {
+	var err error
 	for msg := range r.Messages {
 		resp := imap.NewUntaggedResp([]interface{}{msg.SeqNum, imap.RawString(fetchName), msg.Format()})
-		if err := resp.WriteTo(w); err != nil {
-			return err
+		if err == nil {
+			err = resp.WriteTo(w)
 		}
 	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
Hi,

I found message chan is not closed correctly if the client is closed without sending "logout" command.
How to produce:
Connect to imap server and start to fetch some messages, then kill the imap client.

"Fetch.WriteTo" function reead "r.Messages" chan, if see an error, it returns. But the backend is still writing messages to the chan. So the goroutine is stuck.

http://localhost:6061/debug/pprof/goroutine?debug=1
```
1 @ 0x10387f0 0x1006f5d 0x1006d25 0x17584a5 0x166a519 0x166a703 0x166b0af 0x166e314 0x166d51d 0x166fa54 0x1067c61
#	0x17584a4	Rigel/go/cmd/imap_server/backend.(*Mailbox).ListMessages+0x1034		/Users//work/src/Rigel/go/cmd/imap_server/backend/mailbox.go:168
#	0x166a518	Rigel/go/pkg/utils/eimap/go-imap/server.(*Fetch).handle+0x158		/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/cmd_selected.go:170
#	0x166a702	Rigel/go/pkg/utils/eimap/go-imap/server.(*Fetch).UidHandle+0xc2		/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/cmd_selected.go:195
#	0x166b0ae	Rigel/go/pkg/utils/eimap/go-imap/server.(*Uid).Handle+0xbe		/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/cmd_selected.go:302
#	0x166e313	Rigel/go/pkg/utils/eimap/go-imap/server.(*conn).handleCommand+0x93	/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/conn.go:449
#	0x166d51c	Rigel/go/pkg/utils/eimap/go-imap/server.(*conn).serve+0x93c		/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/conn.go:390
#	0x166fa53	Rigel/go/pkg/utils/eimap/go-imap/server.(*Server).serveConn+0xf3	/Users//work/src/Rigel/go/pkg/utils/eimap/go-imap/server/server.go:315
```


https://github.com/emersion/go-imap/blob/422193a249380f6eaba42429dbc7d977eeeff7b7/responses/fetch.go#L38-L47
