### PR TITLE
Fix small typo in example's doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ func main() {
 	from := uint32(1)
 	to := mbox.Messages
 	if mbox.Messages > 3 {
-		// We're using unsigned integers here, only substract if the result is > 0
+		// We're using unsigned integers here, only subtract if the result is > 0
 		from = mbox.Messages - 3
 	}
 	seqset := new(imap.SeqSet)


### PR DESCRIPTION
Found this small typo while reviewing the examples. Many thanks for this package!