### PR TITLE
Fix custom delimiter bug

### DIFF
--- a/backend/memory/backend.go
+++ b/backend/memory/backend.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/backend"
+	"github.com/emersion/go-imap/utf7"
 )
 
 type Backend struct {
@@ -34,9 +35,11 @@ func New() *Backend {
 		"\r\n" +
 		"Hi there :)"
 
+	inboxName, _ := utf7.Encoding.NewEncoder().String("INBOX")
+
 	user.mailboxes = map[string]*Mailbox{
 		"INBOX": {
-			name: "INBOX",
+			name: inboxName,
 			user: user,
 			Messages: []*Message{
 				{

--- a/commands/append.go
+++ b/commands/append.go
@@ -50,8 +50,8 @@ func (cmd *Append) Parse(fields []interface{}) (err error) {
 	// Parse mailbox name
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/append.go
+++ b/commands/append.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Append is an APPEND command, as defined in RFC 3501 section 6.3.11.
@@ -19,7 +18,7 @@ type Append struct {
 func (cmd *Append) Command() *imap.Command {
 	var args []interface{}
 
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 	args = append(args, imap.FormatMailboxName(mailbox))
 
 	if cmd.Flags != nil {
@@ -50,8 +49,6 @@ func (cmd *Append) Parse(fields []interface{}) (err error) {
 	// Parse mailbox name
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Copy is a COPY command, as defined in RFC 3501 section 6.4.7.
@@ -14,7 +13,7 @@ type Copy struct {
 }
 
 func (cmd *Copy) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      "COPY",
@@ -37,8 +36,6 @@ func (cmd *Copy) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[1]); err != nil {
 		return err
-		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -37,8 +37,8 @@ func (cmd *Copy) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[1]); err != nil {
 		return err
-	} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/create.go
+++ b/commands/create.go
@@ -28,8 +28,8 @@ func (cmd *Create) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/create.go
+++ b/commands/create.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Create is a CREATE command, as defined in RFC 3501 section 6.3.3.
@@ -13,7 +12,7 @@ type Create struct {
 }
 
 func (cmd *Create) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      "CREATE",
@@ -28,8 +27,6 @@ func (cmd *Create) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -28,8 +28,8 @@ func (cmd *Delete) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Delete is a DELETE command, as defined in RFC 3501 section 6.3.3.
@@ -13,7 +12,7 @@ type Delete struct {
 }
 
 func (cmd *Delete) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      "DELETE",
@@ -28,8 +27,6 @@ func (cmd *Delete) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -41,8 +41,8 @@ func (cmd *List) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err := dec.String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := dec.String(mailbox); err != nil {
+		//	return err
 	} else {
 		// TODO: canonical mailbox path
 		cmd.Reference = imap.CanonicalMailboxName(mailbox)
@@ -50,8 +50,8 @@ func (cmd *List) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[1]); err != nil {
 		return err
-	} else if mailbox, err := dec.String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := dec.String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -37,7 +37,7 @@ func (cmd *List) Parse(fields []interface{}) error {
 		return errors.New("No enough arguments")
 	}
 
-	dec := utf7.Encoding.NewDecoder()
+	//dec := utf7.Encoding.NewDecoder()
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err

--- a/commands/list.go
+++ b/commands/list.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // List is a LIST command, as defined in RFC 3501 section 6.3.8. If Subscribed
@@ -22,9 +21,8 @@ func (cmd *List) Command() *imap.Command {
 		name = "LSUB"
 	}
 
-	enc := utf7.Encoding.NewEncoder()
-	ref, _ := enc.String(cmd.Reference)
-	mailbox, _ := enc.String(cmd.Mailbox)
+	ref := cmd.Reference
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      name,
@@ -37,12 +35,8 @@ func (cmd *List) Parse(fields []interface{}) error {
 		return errors.New("No enough arguments")
 	}
 
-	//dec := utf7.Encoding.NewDecoder()
-
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err := dec.String(mailbox); err != nil {
-		//	return err
 	} else {
 		// TODO: canonical mailbox path
 		cmd.Reference = imap.CanonicalMailboxName(mailbox)
@@ -50,8 +44,6 @@ func (cmd *List) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[1]); err != nil {
 		return err
-		//} else if mailbox, err := dec.String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/rename.go
+++ b/commands/rename.go
@@ -33,16 +33,16 @@ func (cmd *Rename) Parse(fields []interface{}) error {
 
 	if existingName, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if existingName, err := dec.String(existingName); err != nil {
-		return err
+		//} else if existingName, err := dec.String(existingName); err != nil {
+		//	return err
 	} else {
 		cmd.Existing = imap.CanonicalMailboxName(existingName)
 	}
 
 	if newName, err := imap.ParseString(fields[1]); err != nil {
 		return err
-	} else if newName, err := dec.String(newName); err != nil {
-		return err
+		//} else if newName, err := dec.String(newName); err != nil {
+		//	return err
 	} else {
 		cmd.New = imap.CanonicalMailboxName(newName)
 	}

--- a/commands/rename.go
+++ b/commands/rename.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Rename is a RENAME command, as defined in RFC 3501 section 6.3.5.
@@ -14,9 +13,8 @@ type Rename struct {
 }
 
 func (cmd *Rename) Command() *imap.Command {
-	enc := utf7.Encoding.NewEncoder()
-	existingName, _ := enc.String(cmd.Existing)
-	newName, _ := enc.String(cmd.New)
+	existingName := cmd.Existing
+	newName := cmd.New
 
 	return &imap.Command{
 		Name:      "RENAME",
@@ -29,20 +27,14 @@ func (cmd *Rename) Parse(fields []interface{}) error {
 		return errors.New("No enough arguments")
 	}
 
-	//dec := utf7.Encoding.NewDecoder()
-
 	if existingName, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if existingName, err := dec.String(existingName); err != nil {
-		//	return err
 	} else {
 		cmd.Existing = imap.CanonicalMailboxName(existingName)
 	}
 
 	if newName, err := imap.ParseString(fields[1]); err != nil {
 		return err
-		//} else if newName, err := dec.String(newName); err != nil {
-		//	return err
 	} else {
 		cmd.New = imap.CanonicalMailboxName(newName)
 	}

--- a/commands/rename.go
+++ b/commands/rename.go
@@ -29,7 +29,7 @@ func (cmd *Rename) Parse(fields []interface{}) error {
 		return errors.New("No enough arguments")
 	}
 
-	dec := utf7.Encoding.NewDecoder()
+	//dec := utf7.Encoding.NewDecoder()
 
 	if existingName, err := imap.ParseString(fields[0]); err != nil {
 		return err

--- a/commands/select.go
+++ b/commands/select.go
@@ -35,8 +35,8 @@ func (cmd *Select) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/select.go
+++ b/commands/select.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Select is a SELECT command, as defined in RFC 3501 section 6.3.1. If ReadOnly
@@ -20,7 +19,7 @@ func (cmd *Select) Command() *imap.Command {
 		name = "EXAMINE"
 	}
 
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      name,
@@ -35,8 +34,6 @@ func (cmd *Select) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/status.go
+++ b/commands/status.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Status is a STATUS command, as defined in RFC 3501 section 6.3.10.
@@ -15,7 +14,7 @@ type Status struct {
 }
 
 func (cmd *Status) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	items := make([]interface{}, len(cmd.Items))
 	for i, item := range cmd.Items {
@@ -35,8 +34,6 @@ func (cmd *Status) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/status.go
+++ b/commands/status.go
@@ -35,8 +35,8 @@ func (cmd *Status) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if mailbox, err := utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	} else {
 		cmd.Mailbox = imap.CanonicalMailboxName(mailbox)
 	}

--- a/commands/subscribe.go
+++ b/commands/subscribe.go
@@ -28,8 +28,8 @@ func (cmd *Subscribe) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	}
 	return nil
 }
@@ -56,8 +56,8 @@ func (cmd *Unsubscribe) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-	} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		return err
+		//} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
+		//	return err
 	}
 	return nil
 }

--- a/commands/subscribe.go
+++ b/commands/subscribe.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/utf7"
 )
 
 // Subscribe is a SUBSCRIBE command, as defined in RFC 3501 section 6.3.6.
@@ -13,7 +12,7 @@ type Subscribe struct {
 }
 
 func (cmd *Subscribe) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      "SUBSCRIBE",
@@ -28,8 +27,6 @@ func (cmd *Subscribe) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	}
 	return nil
 }
@@ -41,7 +38,7 @@ type Unsubscribe struct {
 }
 
 func (cmd *Unsubscribe) Command() *imap.Command {
-	mailbox, _ := utf7.Encoding.NewEncoder().String(cmd.Mailbox)
+	mailbox := cmd.Mailbox
 
 	return &imap.Command{
 		Name:      "UNSUBSCRIBE",
@@ -56,8 +53,6 @@ func (cmd *Unsubscribe) Parse(fields []interface{}) error {
 
 	if mailbox, err := imap.ParseString(fields[0]); err != nil {
 		return err
-		//} else if cmd.Mailbox, err = utf7.Encoding.NewDecoder().String(mailbox); err != nil {
-		//	return err
 	}
 	return nil
 }

--- a/commands/subscribe.go
+++ b/commands/subscribe.go
@@ -25,7 +25,7 @@ func (cmd *Subscribe) Parse(fields []interface{}) error {
 		return errors.New("No enough arguments")
 	}
 
-	if mailbox, err := imap.ParseString(fields[0]); err != nil {
+	if _, err := imap.ParseString(fields[0]); err != nil {
 		return err
 	}
 	return nil
@@ -51,7 +51,7 @@ func (cmd *Unsubscribe) Parse(fields []interface{}) error {
 		return errors.New("No enogh arguments")
 	}
 
-	if mailbox, err := imap.ParseString(fields[0]); err != nil {
+	if _, err := imap.ParseString(fields[0]); err != nil {
 		return err
 	}
 	return nil

--- a/mailbox.go
+++ b/mailbox.go
@@ -120,8 +120,8 @@ func (info *MailboxInfo) Parse(fields []interface{}) error {
 
 // Format mailbox info to fields.
 func (info *MailboxInfo) Format() []interface{} {
-	name, _ := info.Name
-	//utf7.Encoding.NewEncoder().String(info.Name)
+	name := info.Name
+	//name, _ := utf7.Encoding.NewEncoder().String(info.Name)
 	attrs := make([]interface{}, len(info.Attributes))
 	for i, attr := range info.Attributes {
 		attrs[i] = RawString(attr)

--- a/mailbox.go
+++ b/mailbox.go
@@ -3,6 +3,7 @@ package imap
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -126,14 +127,22 @@ func (info *MailboxInfo) Format() []interface{} {
 		attrs[i] = RawString(attr)
 	}
 
+	log.Println("Info: " + fmt.Sprint(info))
+	log.Println("Info Delimiter: " + fmt.Sprint(info.Delimiter))
+
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
 	del := new(Delimiter)
 	del.Delimiter = info.Delimiter
 
+	log.Println("Del: " + fmt.Sprint(del))
+	log.Println("Del Delimiter: " + fmt.Sprint(del.Delimiter))
+
 	if info.Delimiter == "" {
 		del = nil
 	}
+
+	log.Println("NIL Delimiter: " + fmt.Sprint(del))
 
 	// Thunderbird doesn't understand delimiters if not quoted
 	return []interface{}{attrs, del, FormatMailboxName(name)}

--- a/mailbox.go
+++ b/mailbox.go
@@ -129,22 +129,27 @@ func (info *MailboxInfo) Format() []interface{} {
 
 	log.Println("Formatting")
 
-	log.Println("Info: " + fmt.Sprintf("%+v\n", info))
-	log.Println("Info Delimiter: " + fmt.Sprintf("%+v\n", info.Delimiter))
+	log.Println("Info:")
+	fmt.Printf("%+v\n", info)
+	log.Println("Info Delimiter:")
+	fmt.Printf("%+v\n", info.Delimiter)
 
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
 	del := new(Delimiter)
 	del.Delimiter = info.Delimiter
 
-	log.Println("Del: " + fmt.Sprintf("%+v\n", del))
-	log.Println("Del Delimiter: " + fmt.Sprintf("%+v\n", del.Delimiter))
+	log.Println("Del:")
+	fmt.Printf("%+v\n", del)
+	log.Println("Del Delimiter:")
+	fmt.Printf("%+v\n", del.Delimiter)
 
 	if info.Delimiter == "" {
 		del = nil
 	}
 
-	log.Println("NIL Delimiter: " + fmt.Sprintf("%+v\n", del))
+	log.Println("NIL Delimiter:")
+	fmt.Printf("%+v\n", del)
 
 	// Thunderbird doesn't understand delimiters if not quoted
 	return []interface{}{attrs, del, FormatMailboxName(name)}

--- a/mailbox.go
+++ b/mailbox.go
@@ -3,7 +3,6 @@ package imap
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 
@@ -127,29 +126,14 @@ func (info *MailboxInfo) Format() []interface{} {
 		attrs[i] = RawString(attr)
 	}
 
-	log.Println("Formatting")
-
-	log.Println("Info:")
-	fmt.Printf("%#v\n", info)
-	log.Println("Info Delimiter:")
-	fmt.Printf("%#v\n", info.Delimiter)
-
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
 	del := new(Delimiter)
 	del.Delimiter = info.Delimiter
 
-	log.Println("Del:")
-	fmt.Printf("%#v\n", del)
-	log.Println("Del Delimiter:")
-	fmt.Printf("%#v\n", del.Delimiter)
-
 	if info.Delimiter == "" {
 		del = nil
 	}
-
-	log.Println("NIL Delimiter:")
-	fmt.Printf("%#v\n", del)
 
 	// Thunderbird doesn't understand delimiters if not quoted
 	return []interface{}{attrs, del, FormatMailboxName(name)}

--- a/mailbox.go
+++ b/mailbox.go
@@ -9,6 +9,10 @@ import (
 	"github.com/emersion/go-imap/utf7"
 )
 
+type Delimiter struct {
+	Delimiter string
+}
+
 // The primary mailbox, as defined in RFC 3501 section 5.1.
 const InboxName = "INBOX"
 
@@ -124,10 +128,11 @@ func (info *MailboxInfo) Format() []interface{} {
 
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
-	var del interface{}
+	del := new(Delimiter)
+	del.Delimiter = info.Delimiter
 
-	if info.Delimiter != "" {
-		del = info.Delimiter
+	if info.Delimiter == "" {
+		del = nil
 	}
 
 	// Thunderbird doesn't understand delimiters if not quoted

--- a/mailbox.go
+++ b/mailbox.go
@@ -13,6 +13,10 @@ type Delimiter struct {
 	Delimiter string
 }
 
+type FolderName struct {
+	Name string
+}
+
 // The primary mailbox, as defined in RFC 3501 section 5.1.
 const InboxName = "INBOX"
 
@@ -120,7 +124,6 @@ func (info *MailboxInfo) Parse(fields []interface{}) error {
 
 // Format mailbox info to fields.
 func (info *MailboxInfo) Format() []interface{} {
-	name := info.Name
 	//name, _ := utf7.Encoding.NewEncoder().String(info.Name)
 	attrs := make([]interface{}, len(info.Attributes))
 	for i, attr := range info.Attributes {
@@ -136,8 +139,11 @@ func (info *MailboxInfo) Format() []interface{} {
 		del = nil
 	}
 
+	name := new(FolderName)
+	name.Name = info.Name
+
 	// Thunderbird doesn't understand delimiters if not quoted
-	return []interface{}{attrs, del, FormatMailboxName(name)}
+	return []interface{}{attrs, del, name}
 }
 
 // TODO: optimize this
@@ -301,12 +307,4 @@ func (status *MailboxStatus) Format() []interface{} {
 		fields = append(fields, RawString(k), v)
 	}
 	return fields
-}
-
-func FormatMailboxName(name string) interface{} {
-	// Some e-mails servers don't handle quoted INBOX names correctly so we special-case it.
-	if strings.EqualFold(name, "INBOX") {
-		return RawString(name)
-	}
-	return name
 }

--- a/mailbox.go
+++ b/mailbox.go
@@ -120,7 +120,8 @@ func (info *MailboxInfo) Parse(fields []interface{}) error {
 
 // Format mailbox info to fields.
 func (info *MailboxInfo) Format() []interface{} {
-	name, _ := utf7.Encoding.NewEncoder().String(info.Name)
+	name, _ := info.Name
+	//utf7.Encoding.NewEncoder().String(info.Name)
 	attrs := make([]interface{}, len(info.Attributes))
 	for i, attr := range info.Attributes {
 		attrs[i] = RawString(attr)

--- a/mailbox.go
+++ b/mailbox.go
@@ -308,3 +308,11 @@ func (status *MailboxStatus) Format() []interface{} {
 	}
 	return fields
 }
+
+func FormatMailboxName(name string) interface{} {
+	// Some e-mails servers don't handle quoted INBOX names correctly so we special-case it.
+	if strings.EqualFold(name, "INBOX") {
+		return RawString(name)
+	}
+	return name
+}

--- a/mailbox.go
+++ b/mailbox.go
@@ -127,6 +127,8 @@ func (info *MailboxInfo) Format() []interface{} {
 		attrs[i] = RawString(attr)
 	}
 
+	log.Println("Formatting")
+
 	log.Println("Info: " + fmt.Sprint(info))
 	log.Println("Info Delimiter: " + fmt.Sprint(info.Delimiter))
 

--- a/mailbox.go
+++ b/mailbox.go
@@ -124,7 +124,6 @@ func (info *MailboxInfo) Parse(fields []interface{}) error {
 
 // Format mailbox info to fields.
 func (info *MailboxInfo) Format() []interface{} {
-	//name, _ := utf7.Encoding.NewEncoder().String(info.Name)
 	attrs := make([]interface{}, len(info.Attributes))
 	for i, attr := range info.Attributes {
 		attrs[i] = RawString(attr)

--- a/mailbox.go
+++ b/mailbox.go
@@ -130,9 +130,9 @@ func (info *MailboxInfo) Format() []interface{} {
 	log.Println("Formatting")
 
 	log.Println("Info:")
-	fmt.Printf("%+v\n", info)
+	fmt.Printf("%#v\n", info)
 	log.Println("Info Delimiter:")
-	fmt.Printf("%+v\n", info.Delimiter)
+	fmt.Printf("%#v\n", info.Delimiter)
 
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
@@ -140,16 +140,16 @@ func (info *MailboxInfo) Format() []interface{} {
 	del.Delimiter = info.Delimiter
 
 	log.Println("Del:")
-	fmt.Printf("%+v\n", del)
+	fmt.Printf("%#v\n", del)
 	log.Println("Del Delimiter:")
-	fmt.Printf("%+v\n", del.Delimiter)
+	fmt.Printf("%#v\n", del.Delimiter)
 
 	if info.Delimiter == "" {
 		del = nil
 	}
 
 	log.Println("NIL Delimiter:")
-	fmt.Printf("%+v\n", del)
+	fmt.Printf("%#v\n", del)
 
 	// Thunderbird doesn't understand delimiters if not quoted
 	return []interface{}{attrs, del, FormatMailboxName(name)}

--- a/mailbox.go
+++ b/mailbox.go
@@ -129,22 +129,22 @@ func (info *MailboxInfo) Format() []interface{} {
 
 	log.Println("Formatting")
 
-	log.Println("Info: " + fmt.Sprint(info))
-	log.Println("Info Delimiter: " + fmt.Sprint(info.Delimiter))
+	log.Println("Info: " + fmt.Sprintf("%+v\n", info))
+	log.Println("Info Delimiter: " + fmt.Sprintf("%+v\n", info.Delimiter))
 
 	// If the delimiter is NIL, we need to treat it specially by inserting
 	// a nil field (so that it's later converted to an unquoted NIL atom).
 	del := new(Delimiter)
 	del.Delimiter = info.Delimiter
 
-	log.Println("Del: " + fmt.Sprint(del))
-	log.Println("Del Delimiter: " + fmt.Sprint(del.Delimiter))
+	log.Println("Del: " + fmt.Sprintf("%+v\n", del))
+	log.Println("Del Delimiter: " + fmt.Sprintf("%+v\n", del.Delimiter))
 
 	if info.Delimiter == "" {
 		del = nil
 	}
 
-	log.Println("NIL Delimiter: " + fmt.Sprint(del))
+	log.Println("NIL Delimiter: " + fmt.Sprintf("%+v\n", del))
 
 	// Thunderbird doesn't understand delimiters if not quoted
 	return []interface{}{attrs, del, FormatMailboxName(name)}

--- a/write.go
+++ b/write.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"reflect"
 	"strconv"
 	"time"
 	"unicode"
@@ -191,10 +190,6 @@ func (w *Writer) writeField(field interface{}) error {
 	if field == nil {
 		return w.writeString(nilAtom)
 	}
-
-	fmt.Printf("Writing field")
-	fmt.Printf("%#v\n", field)
-	fmt.Printf("%#v\n", reflect.TypeOf(field))
 
 	switch field := field.(type) {
 	case *Delimiter:

--- a/write.go
+++ b/write.go
@@ -197,7 +197,7 @@ func (w *Writer) writeField(field interface{}) error {
 	fmt.Printf("%#v\n", reflect.TypeOf(field))
 
 	switch field := field.(type) {
-	case Delimiter:
+	case *Delimiter:
 		return w.writeDelimiter(field)
 	case RawString:
 		return w.writeString(string(field))

--- a/write.go
+++ b/write.go
@@ -55,6 +55,14 @@ type Writer struct {
 	continues <-chan bool
 }
 
+func (w *Writer) writeDelimiter(d Delimiter) error {
+	del := d.Delimiter
+	if del == "\\" || del == "\"" {
+		del = "\\" + del
+	}
+	return w.writeString("\"" + del + "\"")
+}
+
 // Helper function to write a string to w.
 func (w *Writer) writeString(s string) error {
 	_, err := io.WriteString(w.Writer, s)
@@ -184,6 +192,8 @@ func (w *Writer) writeField(field interface{}) error {
 	}
 
 	switch field := field.(type) {
+	case Delimiter:
+		return w.writeDelimiter(field)
 	case RawString:
 		return w.writeString(string(field))
 	case string:

--- a/write.go
+++ b/write.go
@@ -56,7 +56,7 @@ type Writer struct {
 	continues <-chan bool
 }
 
-func (w *Writer) writeDelimiter(d Delimiter) error {
+func (w *Writer) writeDelimiter(d *Delimiter) error {
 	del := d.Delimiter
 	if del == "\\" || del == "\"" {
 		del = "\\" + del

--- a/write.go
+++ b/write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"reflect"
 	"strconv"
 	"time"
 	"unicode"
@@ -190,6 +191,10 @@ func (w *Writer) writeField(field interface{}) error {
 	if field == nil {
 		return w.writeString(nilAtom)
 	}
+
+	fmt.Printf("Writing field")
+	fmt.Printf("%#v\n", field)
+	fmt.Printf("%#v\n", reflect.TypeOf(field))
 
 	switch field := field.(type) {
 	case Delimiter:

--- a/write.go
+++ b/write.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strconv"
+	"strings"
 	"time"
 	"unicode"
 )
@@ -61,6 +62,13 @@ func (w *Writer) writeDelimiter(d *Delimiter) error {
 		del = "\\" + del
 	}
 	return w.writeString("\"" + del + "\"")
+}
+
+func (w *Writer) writeFolderName(fn *FolderName) error {
+	if strings.EqualFold(fn.Name, "INBOX") {
+		return w.writeString("INBOX")
+	}
+	return w.writeQuotedOrLiteral(fn.Name)
 }
 
 // Helper function to write a string to w.
@@ -194,6 +202,8 @@ func (w *Writer) writeField(field interface{}) error {
 	switch field := field.(type) {
 	case *Delimiter:
 		return w.writeDelimiter(field)
+	case *FolderName:
+		return w.writeFolderName(field)
 	case RawString:
 		return w.writeString(string(field))
 	case string:


### PR DESCRIPTION
This Pull Request does fix the bug that makes it impossible to have every custom delimiter.
For example, the character with hex `0x1C` was encoded by UTF-7 and would become `&HA-`.
IMAP clients like Thunderbird then could not detect it being an delimiter.
Therefore, I removed all UTF-7 encoding of the folders and added it to the backend.

Then, if you use the hex `0x1C` as delimiter, then you should encode your folder name in the backend like this:
When you have a folder with name `folder` having a folder `subfolder` having a folder `subsubfolder`, then encode this folder names seperate from each other. Then append this names together with your delimiter (in this case the hex `0x1C`).
You will get `foldersubfoldersubsubfolder`, where `` is your delimiter.