### PR TITLE
utf7: reset ascii boolean after decode while destination is short.

### DIFF
--- a/utf7/decoder.go
+++ b/utf7/decoder.go
@@ -77,9 +77,7 @@ func (d *decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err er
 		}
 
 		if nDst+len(b) > len(dst) {
-			if atEOF {
-				d.ascii = true
-			}
+			d.ascii = true
 			err = transform.ErrShortDst
 			return
 		}

--- a/utf7/decoder_test.go
+++ b/utf7/decoder_test.go
@@ -1,6 +1,7 @@
 package utf7_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/emersion/go-imap/utf7"
@@ -75,6 +76,10 @@ var decode = []struct {
 	// Long input with Base64 at the end
 	{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &2D3eCg- &2D3eCw- &2D3eDg-",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \U0001f60a \U0001f60b \U0001f60e", true},
+
+	// Long input in Base64 between short ASCII
+	{"00000000000000000000 &MEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEIwQjBCMEI- 00000000000000000000",
+		"00000000000000000000 " + strings.Repeat("\U00003042", 37) + " 00000000000000000000", true},
 
 	// ASCII in Base64
 	{"&AGE-", "", false},            // "a"


### PR DESCRIPTION
Hello,  
Thanks for this useful library.  
In Japanese environment, I found a bug in decoding UTF-7.

In `decoder.Transform`, there are two cases to return `transform.ErrShortDst`.  
The second case occurs after decode Base64. This is the point.  

When whole decoded string cannot be passed to `dst`, next call of `decoder.Transform` will begin with decoding Base64(repeat last decode and try to copy them to `dst` again).  
So, `decoder.ascii` should be set `true` before return `transform.ErrShortDst`. Otherwise, misdetection of Null shift makes error.