### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: "https://webchat.freenode.net/##emersion"
+    about: "Please ask questions in ##emersion on Freenode"

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,7 @@
+<!--
+
+Please read the following before submitting a new issue:
+
+Do NOT create GitHub issues if you have a question about go-imap or about the IMAP protocol in general. Ask questions on IRC in ##emersion on Freenode.
+
+-->


### PR DESCRIPTION
Reject issues for questions about go-imap and IMAP in general. Our
issue tracker is filled with questions that aren't actionable.

cc @foxcpp