### PR TITLE
Fetch: Ignore unilateral updates from the server

### DIFF
--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -152,7 +152,7 @@ func (c *Client) fetch(uid bool, seqset *imap.SeqSet, items []imap.FetchItem, ch
 		cmd = &commands.Uid{Cmd: cmd}
 	}
 
-	res := &responses.Fetch{Messages: ch}
+	res := &responses.Fetch{Messages: ch, SeqSet: seqset, Uid: uid}
 
 	status, err := c.execute(cmd, res)
 	if err != nil {
@@ -211,7 +211,7 @@ func (c *Client) store(uid bool, seqset *imap.SeqSet, item imap.StoreItem, value
 
 	var h responses.Handler
 	if ch != nil {
-		h = &responses.Fetch{Messages: ch}
+		h = &responses.Fetch{Messages: ch, SeqSet: seqset, Uid: uid}
 	}
 
 	status, err := c.execute(cmd, h)

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -378,6 +378,94 @@ func TestClient_Fetch_Uid(t *testing.T) {
 	}
 }
 
+func TestClient_Fetch_Unilateral(t *testing.T) {
+	c, s := newTestClient(t)
+	defer s.Close()
+
+	setClientState(c, imap.SelectedState, nil)
+
+	seqset, _ := imap.ParseSeqSet("1:4")
+	fields := []imap.FetchItem{imap.FetchFlags}
+
+	done := make(chan error, 1)
+	messages := make(chan *imap.Message, 3)
+	go func() {
+		done <- c.Fetch(seqset, fields, messages)
+	}()
+
+	tag, cmd := s.ScanCmd()
+	if cmd != "FETCH 1:4 (FLAGS)" {
+		t.Fatalf("client sent command %v, want %v", cmd, "FETCH 1:4 (FLAGS)")
+	}
+
+	s.WriteString("* 2 FETCH (FLAGS (\\Seen))\r\n")
+	s.WriteString("* 123 FETCH (FLAGS (\\Deleted))\r\n")
+	s.WriteString("* 4 FETCH (FLAGS (\\Seen))\r\n")
+	s.WriteString(tag + " OK FETCH completed\r\n")
+
+	if err := <-done; err != nil {
+		t.Fatalf("c.Fetch() = %v", err)
+	}
+
+	msg := <-messages
+	if msg.SeqNum != 2 {
+		t.Errorf("First message has bad sequence number: %v", msg.SeqNum)
+	}
+	msg = <-messages
+	if msg.SeqNum != 4 {
+		t.Errorf("Second message has bad sequence number: %v", msg.SeqNum)
+	}
+
+	_, ok := <-messages
+	if ok {
+		t.Errorf("More than two messages")
+	}
+}
+
+func TestClient_Fetch_Unilateral_Uid(t *testing.T) {
+	c, s := newTestClient(t)
+	defer s.Close()
+
+	setClientState(c, imap.SelectedState, nil)
+
+	seqset, _ := imap.ParseSeqSet("1:4")
+	fields := []imap.FetchItem{imap.FetchFlags}
+
+	done := make(chan error, 1)
+	messages := make(chan *imap.Message, 3)
+	go func() {
+		done <- c.UidFetch(seqset, fields, messages)
+	}()
+
+	tag, cmd := s.ScanCmd()
+	if cmd != "UID FETCH 1:4 (FLAGS)" {
+		t.Fatalf("client sent command %v, want %v", cmd, "UID FETCH 1:4 (FLAGS)")
+	}
+
+	s.WriteString("* 23 FETCH (UID 2 FLAGS (\\Seen))\r\n")
+	s.WriteString("* 123 FETCH (FLAGS (\\Deleted))\r\n")
+	s.WriteString("* 49 FETCH (UID 4 FLAGS (\\Seen))\r\n")
+	s.WriteString(tag + " OK FETCH completed\r\n")
+
+	if err := <-done; err != nil {
+		t.Fatalf("c.Fetch() = %v", err)
+	}
+
+	msg := <-messages
+	if msg.Uid != 2 {
+		t.Errorf("First message has bad UID: %v", msg.Uid)
+	}
+	msg = <-messages
+	if msg.Uid != 4 {
+		t.Errorf("Second message has bad UID: %v", msg.Uid)
+	}
+
+	_, ok := <-messages
+	if ok {
+		t.Errorf("More than two messages")
+	}
+}
+
 func TestClient_Store(t *testing.T) {
 	c, s := newTestClient(t)
 	defer s.Close()

--- a/responses/fetch.go
+++ b/responses/fetch.go
@@ -10,6 +10,8 @@ const fetchName = "FETCH"
 // See RFC 3501 section 7.4.2
 type Fetch struct {
 	Messages chan *imap.Message
+	SeqSet   *imap.SeqSet
+	Uid      bool
 }
 
 func (r *Fetch) Handle(resp imap.Resp) error {
@@ -29,6 +31,25 @@ func (r *Fetch) Handle(resp imap.Resp) error {
 	msg := &imap.Message{SeqNum: seqNum}
 	if err := msg.Parse(msgFields); err != nil {
 		return err
+	}
+
+	var num uint32
+	if r.Uid {
+		num = msg.Uid
+	} else {
+		num = seqNum
+	}
+
+	if r.Uid && msg.Uid == 0 {
+		// we requested UIDs and got a message without --> unilateral update --> ignore
+		return ErrUnhandled
+	}
+
+	// check whether we obtained a result we requested with our SeqSet
+	// If it does not, but the msg contains a UID and the set is dynamic (i.e. * or n:*), the server
+	// supplied us with the max UID. That is fine.
+	if !r.SeqSet.Contains(num) && (!r.Uid || !r.SeqSet.Dynamic()) {
+		return ErrUnhandled
 	}
 
 	r.Messages <- msg

--- a/responses/fetch.go
+++ b/responses/fetch.go
@@ -33,16 +33,16 @@ func (r *Fetch) Handle(resp imap.Resp) error {
 		return err
 	}
 
+	if r.Uid && msg.Uid == 0 {
+		// we requested UIDs and got a message without --> unilateral update --> ignore
+		return ErrUnhandled
+	}
+
 	var num uint32
 	if r.Uid {
 		num = msg.Uid
 	} else {
 		num = seqNum
-	}
-
-	if r.Uid && msg.Uid == 0 {
-		// we requested UIDs and got a message without --> unilateral update --> ignore
-		return ErrUnhandled
 	}
 
 	// check whether we obtained a result we requested with our SeqSet


### PR DESCRIPTION
The server can send unilateral updates as part of fetch results. Those should be ignored by Fetch and be handled by the `Updates` channel.

This fixes #430.
