### PR TITLE
Add IDLE to capabilities list

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -163,7 +163,7 @@ func (c *conn) Close() error {
 }
 
 func (c *conn) Capabilities() []string {
-	caps := []string{"IMAP4rev1", "LITERAL+", "SASL-IR", "CHILDREN", "UNSELECT", "MOVE"}
+	caps := []string{"IMAP4rev1", "LITERAL+", "SASL-IR", "CHILDREN", "UNSELECT", "MOVE", "IDLE"}
 
 	appendLimitSet := false
 	if c.ctx.State == imap.AuthenticatedState {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Extnesions that are always advertised by go-imap server.
-const builtinExtensions = "LITERAL+ SASL-IR CHILDREN UNSELECT MOVE APPENDLIMIT"
+const builtinExtensions = "LITERAL+ SASL-IR CHILDREN UNSELECT MOVE IDLE APPENDLIMIT"
 
 func testServer(t *testing.T) (s *server.Server, conn net.Conn) {
 	bkd := memory.New()


### PR DESCRIPTION
IDLE was changed into a built-in extension, but the default capabilities list was never updated to include it. The go-imap/client library (and probably any other sane IMAP client) resorts to polling if the IDLE cap isn't present. This PR simply adds IDLE to the list.