### PR TITLE
search: allow users to select us-ascii charset

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -83,6 +83,12 @@ type Client struct {
 	// access.
 	locker sync.Mutex
 
+	// This flag is set when the first search query fails with a BADCHARSET
+	// error. Subsequent queries will be performed with the US-ASCII
+	// charset. According to RFC 3501, SEARCH must only support US-ASCII;
+	// other charsets are optional.
+	utf8SearchUnsupported bool
+
 	// A channel to which unilateral updates from the server will be sent. An
 	// update can be one of: *StatusUpdate, *MailboxUpdate, *MessageUpdate,
 	// *ExpungeUpdate. Note that blocking this channel blocks the whole client,

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -117,10 +117,15 @@ func (c *Client) executeSearch(uid bool, criteria *imap.SearchCriteria, charset 
 }
 
 func (c *Client) search(uid bool, criteria *imap.SearchCriteria) (ids []uint32, err error) {
-	ids, status, err := c.executeSearch(uid, criteria, "UTF-8")
+	charset := "UTF-8"
+	if c.utf8SearchUnsupported {
+		charset = "US-ASCII"
+	}
+	ids, status, err := c.executeSearch(uid, criteria, charset)
 	if status != nil && status.Code == imap.CodeBadCharset {
 		// Some servers don't support UTF-8
 		ids, _, err = c.executeSearch(uid, criteria, "US-ASCII")
+		c.utf8SearchUnsupported = true
 	}
 	return
 }


### PR DESCRIPTION
Add a UseUSASCII bool flag to the search criteria to indicate that this
charset should be used for the search command. Default charset remains
utf-8.

According to RFC 3501, the search command must only support us-ascii;
support for other charset is optional.

Currently, us-ascii is the fallback charset when the search command with
utf-8 returns a badcharset error. However, this means that we always
execute two search calls to servers that don't support utf-8. More
importantly, it often leads to a server-side disconnect after multiple
badcharset errors. This can be avoid with the proposed flag.