### PR TITLE
Enable remove quote mark

### DIFF
--- a/commands/enable.go
+++ b/commands/enable.go
@@ -10,9 +10,14 @@ type Enable struct {
 }
 
 func (cmd *Enable) Command() *imap.Command {
+	args := make([]interface{}, len(cmd.Caps))
+	for i, c := range cmd.Caps {
+		args[i] = imap.RawString(c)
+	}
+
 	return &imap.Command{
 		Name:      "ENABLE",
-		Arguments: imap.FormatStringList(cmd.Caps),
+		Arguments: args,
 	}
 }
 


### PR DESCRIPTION
fixes that the `ENABLE` command adds quote mark to the capabilities