### PR TITLE
Add support for SEARCHRES

### DIFF
--- a/imapserver/capability.go
+++ b/imapserver/capability.go
@@ -64,11 +64,11 @@ func (c *Conn) availableCaps() []imap.Cap {
 				imap.CapEnable,
 				imap.CapIdle,
 			}...)
-			// TODO: implement imap.CapSearchRes
 			addAvailableCaps(&caps, available, []imap.Cap{
 				imap.CapNamespace,
 				imap.CapUIDPlus,
 				imap.CapESearch,
+				imap.CapSearchRes,
 				imap.CapListExtended,
 				imap.CapListStatus,
 				imap.CapMove,

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -461,6 +461,11 @@ func (dec *Decoder) ExpectMailbox(ptr *string) bool {
 }
 
 func (dec *Decoder) ExpectSeqSet(ptr *imap.SeqSet) bool {
+	if dec.Special('$') {
+		*ptr = imap.SearchRes()
+		return true
+	}
+
 	var s string
 	if !dec.Expect(dec.Func(&s, isSeqSetChar), "sequence-set") {
 		return false

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -159,11 +159,12 @@ func (enc *Encoder) Mailbox(name string) *Encoder {
 }
 
 func (enc *Encoder) SeqSet(seqSet imap.SeqSet) *Encoder {
-	if len(seqSet) == 0 {
+	s := seqSet.String()
+	if s == "" {
 		enc.setErr(fmt.Errorf("imapwire: cannot encode empty sequence set"))
 		return enc
 	}
-	return enc.writeString(seqSet.String())
+	return enc.writeString(s)
 }
 
 func (enc *Encoder) Flag(flag imap.Flag) *Encoder {

--- a/seqset.go
+++ b/seqset.go
@@ -214,6 +214,9 @@ func (s SeqSet) Nums() (nums []uint32, ok bool) {
 
 // String returns a sorted representation of all contained sequence values.
 func (s SeqSet) String() string {
+	if IsSearchRes(s) {
+		return "$"
+	}
 	if len(s) == 0 {
 		return ""
 	}


### PR DESCRIPTION
Is the `imap.SearchRes` hack reasonable?