### PR TITLE
imapclient: don't encode UTF-8 quoted strings with UTF8=ACCEPT

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -293,7 +293,7 @@ func (c *Client) beginCommand(name string, cmd command) *commandEncoder {
 	c.cmdTag++
 	tag := fmt.Sprintf("T%v", c.cmdTag)
 	c.pendingCmds = append(c.pendingCmds, cmd)
-	quotedUTF8 := c.caps.Has(imap.CapIMAP4rev2) || c.caps.Has(imap.CapUTF8Accept)
+	quotedUTF8 := c.caps.Has(imap.CapIMAP4rev2)
 	literalMinus := c.caps.Has(imap.CapLiteralMinus)
 	c.mutex.Unlock()
 


### PR DESCRIPTION
UTF8=ACCEPT seems to be mostly for mailbox names and server-to-client quoted strings. It doesn't seem like we can send arbitrary UTF-8 quoted strings when the server supports UTF8=ACCEPT. This is still fine with IMAP4rev2.