### PR TITLE
Keep caps in cache to avoid Literal to be stuck

### DIFF
--- a/imapclient/append.go
+++ b/imapclient/append.go
@@ -13,6 +13,8 @@ import (
 //
 // The options are optional.
 func (c *Client) Append(mailbox string, size int64, options *imap.AppendOptions) *AppendCommand {
+	// Keep caps in cache to avoid beginCommand to be stuck
+	c.Caps()
 	cmd := &AppendCommand{}
 	cmd.enc = c.beginCommand("APPEND", cmd)
 	cmd.enc.SP().Mailbox(mailbox).SP()

--- a/imapclient/append.go
+++ b/imapclient/append.go
@@ -13,8 +13,6 @@ import (
 //
 // The options are optional.
 func (c *Client) Append(mailbox string, size int64, options *imap.AppendOptions) *AppendCommand {
-	// Keep caps in cache to avoid beginCommand to be stuck
-	c.Caps()
 	cmd := &AppendCommand{}
 	cmd.enc = c.beginCommand("APPEND", cmd)
 	cmd.enc.SP().Mailbox(mailbox).SP()

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -962,7 +962,10 @@ func (ce *commandEncoder) flush() {
 // Literal encodes a literal.
 func (ce *commandEncoder) Literal(size int64) io.WriteCloser {
 	var contReq *imapwire.ContinuationRequest
-	if size > 4096 || !ce.client.caps.Has(imap.CapLiteralMinus) {
+	ce.client.mutex.Lock()
+	hasCapLiteralMinus := ce.client.caps.Has(imap.CapLiteralMinus)
+	ce.client.mutex.Unlock()
+	if size > 4096 || !hasCapLiteralMinus {
 		contReq = ce.client.registerContReq(ce.cmd)
 	}
 	ce.client.setWriteTimeout(literalWriteTimeout)

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -962,7 +962,7 @@ func (ce *commandEncoder) flush() {
 // Literal encodes a literal.
 func (ce *commandEncoder) Literal(size int64) io.WriteCloser {
 	var contReq *imapwire.ContinuationRequest
-	if size > 4096 || !ce.client.Caps().Has(imap.CapLiteralMinus) {
+	if size > 4096 || !ce.client.caps.Has(imap.CapLiteralMinus) {
 		contReq = ce.client.registerContReq(ce.cmd)
 	}
 	ce.client.setWriteTimeout(literalWriteTimeout)


### PR DESCRIPTION
When Literal() is called from append command, the server capabilities may not have been retrieved yet. Therefore, a call to Caps() may trigger the encoding of the capability command which will cause a deadlock (we are already encoding the append command). To solve this, we call Caps() before the append command to ensure it is properly cached.