### PR TITLE
Add search for Gmail thread Id.

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -73,6 +73,8 @@ const (
 	CapUTF8Accept       Cap = "UTF8=ACCEPT"        // RFC 6855
 	CapUTF8Only         Cap = "UTF8=ONLY"          // RFC 6855
 	CapWithin           Cap = "WITHIN"             // RFC 5032
+
+	CapGmailExtension Cap = "X-GM-EXT-1"
 )
 
 var imap4rev2Caps = CapSet{

--- a/fetch.go
+++ b/fetch.go
@@ -38,6 +38,7 @@ var (
 	FetchItemInternalDate  FetchItem = FetchItemKeyword("INTERNALDATE")
 	FetchItemRFC822Size    FetchItem = FetchItemKeyword("RFC822.SIZE")
 	FetchItemUID           FetchItem = FetchItemKeyword("UID")
+	FetchItemGmailThreadId FetchItem = FetchItemKeyword("X-GM-THRID")
 )
 
 type PartSpecifier string

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -322,6 +322,9 @@ func (c *Client) beginCommand(name string, cmd command) *commandEncoder {
 	wireEnc.NewContinuationRequest = func() *imapwire.ContinuationRequest {
 		return c.registerContReq(cmd)
 	}
+	if c.caps.Has(imap.CapGmailExtension) {
+		wireEnc.ImapThreadIdTag = "X-GM-THRID"
+	}
 
 	baseCmd := cmd.base()
 	*baseCmd = Command{

--- a/imapclient/search.go
+++ b/imapclient/search.go
@@ -182,6 +182,10 @@ func writeSearchKey(enc *imapwire.Encoder, criteria *imap.SearchCriteria) {
 		encodeItem("SMALLER").SP().Number64(criteria.Smaller)
 	}
 
+	if criteria.ThreadId > 0 && enc.ImapThreadIdTag != "" {
+		encodeItem(enc.ImapThreadIdTag).SP().Number64(criteria.ThreadId)
+	}
+
 	for _, not := range criteria.Not {
 		encodeItem("NOT").SP()
 		writeSearchKey(enc, &not)

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -33,6 +33,10 @@ type Encoder struct {
 	side    ConnSide
 	err     error
 	literal bool
+	// ImapThreadIdTag contains the tag identifying the imap thread id extension
+	// regarding imap servers like Gmail.
+	// https://developers.google.com/gmail/imap/imap-extensions?hl=en#access_to_the_thread_id_x-gm-thrid
+	ImapThreadIdTag string
 }
 
 // NewEncoder creates a new encoder.

--- a/search.go
+++ b/search.go
@@ -46,6 +46,8 @@ type SearchCriteria struct {
 
 	Not []SearchCriteria
 	Or  [][2]SearchCriteria
+
+	ThreadId int64
 }
 
 type SearchCriteriaHeaderField struct {


### PR DESCRIPTION
Gmail has implemented thread id (https://developers.google.com/gmail/imap/imap-extensions?hl=en#access_to_the_thread_id_x-gm-thrid)
This is a basic way to search messages with the Gmail thread id.