### PR TITLE
Set IMAP Client timeout options.

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -611,12 +611,12 @@ func (c *Client) handleFetch(seqNum uint32) error {
 		}
 
 		if done != nil {
-			c.setReadTimeout(literalReadTimeout)
+			c.setReadTimeout(*c.options.LiteralReadTimeout)
 		}
 		items <- item
 		if done != nil {
 			<-done
-			c.setReadTimeout(respReadTimeout)
+			c.setReadTimeout(*c.options.RespReadTimeout)
 		}
 		return nil
 	})

--- a/imapclient/idle.go
+++ b/imapclient/idle.go
@@ -49,7 +49,7 @@ func (cmd *IdleCommand) Close() error {
 	if cmd.enc == nil {
 		return fmt.Errorf("imapclient: IDLE command closed twice")
 	}
-	cmd.enc.client.setWriteTimeout(cmdWriteTimeout)
+	cmd.enc.client.setWriteTimeout(*cmd.enc.client.options.CmdWriteTimeout)
 	_, err := cmd.enc.client.bw.WriteString("DONE\r\n")
 	if err == nil {
 		err = cmd.enc.client.bw.Flush()


### PR DESCRIPTION
User wanting to use its own timeout options can set them by populating Options before dialing with IMAP server.
Added PtrT() to get a pointer from any type.