### PR TITLE
imap: allow multiple SeqSets per SearchCriteria

### DIFF
--- a/imapclient/search.go
+++ b/imapclient/search.go
@@ -136,11 +136,11 @@ func writeSearchKey(enc *imapwire.Encoder, criteria *imap.SearchCriteria) {
 		return enc.Atom(s)
 	}
 
-	if len(criteria.SeqNum) > 0 {
-		encodeItem(criteria.SeqNum.String())
+	for _, seqSet := range criteria.SeqNum {
+		encodeItem(seqSet.String())
 	}
-	if len(criteria.UID) > 0 {
-		encodeItem("UID").SP().SeqSet(criteria.UID)
+	for _, seqSet := range criteria.UID {
+		encodeItem("UID").SP().SeqSet(seqSet)
 	}
 
 	if !criteria.Since.IsZero() && !criteria.Before.IsZero() && criteria.Before.Sub(criteria.Since) == 24*time.Hour {

--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -312,8 +312,12 @@ func (mbox *MailboxView) Search(numKind imapserver.NumKind, criteria *imap.Searc
 	mbox.mutex.Lock()
 	defer mbox.mutex.Unlock()
 
-	mbox.staticSeqSet(criteria.SeqNum, imapserver.NumKindSeq)
-	mbox.staticSeqSet(criteria.UID, imapserver.NumKindUID)
+	for _, seqSet := range criteria.SeqNum {
+		mbox.staticSeqSet(seqSet, imapserver.NumKindSeq)
+	}
+	for _, seqSet := range criteria.UID {
+		mbox.staticSeqSet(seqSet, imapserver.NumKindUID)
+	}
 
 	data := imap.SearchData{
 		UID: numKind == imapserver.NumKindUID,

--- a/imapserver/imapmemserver/message.go
+++ b/imapserver/imapmemserver/message.go
@@ -250,11 +250,15 @@ func (msg *message) store(store *imap.StoreFlags) {
 }
 
 func (msg *message) search(seqNum uint32, criteria *imap.SearchCriteria) bool {
-	if criteria.SeqNum != nil && (seqNum == 0 || !criteria.SeqNum.Contains(seqNum)) {
-		return false
+	for _, seqSet := range criteria.SeqNum {
+		if seqNum == 0 || !seqSet.Contains(seqNum) {
+			return false
+		}
 	}
-	if criteria.UID != nil && !criteria.UID.Contains(msg.uid) {
-		return false
+	for _, seqSet := range criteria.UID {
+		if !seqSet.Contains(msg.uid) {
+			return false
+		}
 	}
 	if !matchDate(msg.t, criteria.Since, criteria.Before) {
 		return false

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -185,7 +185,7 @@ func readSearchKeyWithAtom(criteria *imap.SearchCriteria, dec *imapwire.Decoder,
 		if !dec.ExpectSP() || !dec.ExpectSeqSet(&seqSet) {
 			return dec.Err()
 		}
-		criteria.UID = seqSet // TODO: intersect
+		criteria.UID = append(criteria.UID, seqSet)
 	case "ANSWERED", "DELETED", "DRAFT", "FLAGGED", "RECENT", "SEEN":
 		criteria.Flag = append(criteria.Flag, searchKeyFlag(key))
 	case "UNANSWERED", "UNDELETED", "UNDRAFT", "UNFLAGGED", "UNSEEN":
@@ -308,7 +308,7 @@ func readSearchKeyWithAtom(criteria *imap.SearchCriteria, dec *imapwire.Decoder,
 		if err != nil {
 			return err
 		}
-		criteria.SeqNum = seqSet // TODO: intersect
+		criteria.SeqNum = append(criteria.SeqNum, seqSet)
 	}
 	return nil
 }

--- a/search.go
+++ b/search.go
@@ -18,8 +18,8 @@ type SearchOptions struct {
 // When multiple fields are populated, the result is the intersection ("and"
 // function) of all messages that match the fields.
 type SearchCriteria struct {
-	SeqNum SeqSet
-	UID    SeqSet
+	SeqNum []SeqSet
+	UID    []SeqSet
 
 	// Only the date is used, the time and timezone are ignored
 	Since      time.Time


### PR DESCRIPTION
Merging multiple sequence sets is non-trivial: to handle the special symbol '*', the merging logic needs to know about the maximum sequence number or UID.

Alternative to #522