### PR TITLE
imapclient: fix FetchItems to end encoded list

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -74,6 +74,8 @@ func writeFetchItems(enc *imapwire.Encoder, uid bool, options *imap.FetchOptions
 	for _, bss := range options.BinarySectionSize {
 		writeFetchItemBinarySectionSize(listEnc.Item(), bss)
 	}
+
+	listEnc.End()
 }
 
 func writeFetchItemBodySection(enc *imapwire.Encoder, item *imap.FetchItemBodySection) {


### PR DESCRIPTION
#517 uses the new `enc.BeginList()` to encode fetch options over the IMAP protocol, but never calls `.End()` so the closing `)` character is never written out, causing errors like `T6 BAD Could not parse command`.