### PR TITLE
imapclient: add SPECIAL-USE LIST option support

### DIFF
--- a/imapclient/list.go
+++ b/imapclient/list.go
@@ -25,6 +25,9 @@ func getSelectOpts(options *imap.ListOptions) []string {
 	if options.SelectRecursiveMatch {
 		l = append(l, "RECURSIVEMATCH")
 	}
+	if options.SelectSpecialUse {
+		l = append(l, "SPECIAL-USE")
+	}
 	return l
 }
 
@@ -42,6 +45,9 @@ func getReturnOpts(options *imap.ListOptions) []string {
 	}
 	if options.ReturnStatus != nil {
 		l = append(l, "STATUS")
+	}
+	if options.ReturnSpecialUse {
+		l = append(l, "SPECIAL-USE")
 	}
 	return l
 }

--- a/list.go
+++ b/list.go
@@ -5,10 +5,12 @@ type ListOptions struct {
 	SelectSubscribed     bool
 	SelectRemote         bool
 	SelectRecursiveMatch bool // requires SelectSubscribed to be set
+	SelectSpecialUse     bool // requires SPECIAL-USE
 
 	ReturnSubscribed bool
 	ReturnChildren   bool
 	ReturnStatus     *StatusOptions // requires IMAP4rev2 or LIST-STATUS
+	ReturnSpecialUse bool           // requires SPECIAL-USE
 }
 
 // ListData is the mailbox data returned by a LIST command.


### PR DESCRIPTION
Servers are allowed to optionally send SPECIAL-USE mailbox attributes. Add support for clients to explicitly request that SPECIAL-USE attributes be sent.