### PR TITLE
add rfc 8457 mailbox attr

### DIFF
--- a/imap.go
+++ b/imap.go
@@ -60,13 +60,14 @@ const (
 	MailboxAttrRemote        MailboxAttr = "\\Remote"
 
 	// Role (aka. "special-use") attributes
-	MailboxAttrAll     MailboxAttr = "\\All"
-	MailboxAttrArchive MailboxAttr = "\\Archive"
-	MailboxAttrDrafts  MailboxAttr = "\\Drafts"
-	MailboxAttrFlagged MailboxAttr = "\\Flagged"
-	MailboxAttrJunk    MailboxAttr = "\\Junk"
-	MailboxAttrSent    MailboxAttr = "\\Sent"
-	MailboxAttrTrash   MailboxAttr = "\\Trash"
+	MailboxAttrAll       MailboxAttr = "\\All"
+	MailboxAttrArchive   MailboxAttr = "\\Archive"
+	MailboxAttrDrafts    MailboxAttr = "\\Drafts"
+	MailboxAttrFlagged   MailboxAttr = "\\Flagged"
+	MailboxAttrJunk      MailboxAttr = "\\Junk"
+	MailboxAttrSent      MailboxAttr = "\\Sent"
+	MailboxAttrTrash     MailboxAttr = "\\Trash"
+	MailboxAttrImportant MailboxAttr = "\\Important" // RFC 8457
 )
 
 // Flag is a message flag.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -135,6 +135,7 @@ func canonInit() {
 		imap.MailboxAttrJunk,
 		imap.MailboxAttrSent,
 		imap.MailboxAttrTrash,
+		imap.MailboxAttrImportant,
 	}
 
 	canonFlag = make(map[string]imap.Flag)


### PR DESCRIPTION
I noticed that "\Important" attr is missing but keyword "$Important" is present
https://www.rfc-editor.org/rfc/rfc8457.html