### PR TITLE
imapclient: Close returned err.NetClosed after Logout

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -22,6 +22,7 @@ package imapclient
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -317,12 +318,12 @@ func (c *Client) Close() error {
 	c.mutex.Unlock()
 
 	// Ignore net.ErrClosed here, because we also call conn.Close in c.read
-	if err := c.conn.Close(); err != nil && err != net.ErrClosed {
+	if err := c.conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		return err
 	}
 
 	<-c.decCh
-	if err := c.decErr; err != nil {
+	if err := c.decErr; err != nil && !errors.Is(err, net.ErrClosed) {
 		return err
 	}
 

--- a/imapclient/client_test.go
+++ b/imapclient/client_test.go
@@ -72,6 +72,18 @@ func TestLogin(t *testing.T) {
 	}
 }
 
+func TestLogout(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateAuthenticated)
+	defer server.Close()
+
+	if err := client.Logout().Wait(); err != nil {
+		t.Errorf("Logout().Wait() = %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Errorf("Close() = %v", err)
+	}
+}
+
 func TestIdle(t *testing.T) {
 	client, server := newClientServerPair(t, imap.ConnStateSelected)
 	defer client.Close()


### PR DESCRIPTION
server closes connection after Logout and Close should not return error NetClosed when called after logout 