### PR TITLE
imapclient: deadlock on error before greeting

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -910,8 +910,15 @@ func (c *Client) readResponseData(typ string) error {
 
 // WaitGreeting waits for the server's initial greeting.
 func (c *Client) WaitGreeting() error {
-	<-c.greetingCh
-	return c.greetingErr
+	select {
+	case <-c.greetingCh:
+		return c.greetingErr
+	case <-c.decCh:
+		if c.decErr != nil {
+			return fmt.Errorf("got error before greeting: %v", c.decErr)
+		}
+		return fmt.Errorf("connection closed before greeting")
+	}
 }
 
 // Noop sends a NOOP command.

--- a/imapclient/client_test.go
+++ b/imapclient/client_test.go
@@ -142,3 +142,19 @@ func TestFetch_closeUnreadBody(t *testing.T) {
 		t.Fatalf("UIDFetch().Close() = %v", err)
 	}
 }
+
+func TestWaitGreeting_eof(t *testing.T) {
+	// bad server: connected but without greeting
+	clientConn, serverConn := net.Pipe()
+
+	client := imapclient.New(clientConn, nil)
+	defer client.Close()
+
+	if err := serverConn.Close(); err != nil {
+		t.Fatalf("serverConn.Close() = %v", err)
+	}
+
+	if err := client.WaitGreeting(); err == nil {
+		t.Fatalf("WaitGreeting() should fail")
+	}
+}


### PR DESCRIPTION
I was testing timeouts and got a deadlock in WaitGreeting 