### PR TITLE
fetch: ensure field names are Atoms

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -101,7 +101,8 @@ func writeFetchItemBodySection(enc *imapwire.Encoder, item *imap.FetchItemBodySe
 
 		if len(headerList) > 0 {
 			enc.SP().List(len(headerList), func(i int) {
-				enc.String(headerList[i])
+				// This should be a string, but some servers don't recognize that
+				enc.Atom(headerList[i])
 			})
 		}
 	}


### PR DESCRIPTION
This PR makes sure the fields in FETCH/SEARCH are atoms.

The spec says it is allowed to have strings (ie with double quotes) here, but I'm on an IMAP server that doesn't totally respect that:

```
> A004 SEARCH HEADER Message-Id <ea-mime-REDACTED@REDACTED.localdomain>
< * SEARCH 1
< A004 OK SEARCH done
```

```
> A004 FETCH 1 (BODY[HEADER.FIELDS (Message-ID)])
< * 1 FETCH (BODY[HEADER.FIELDS (MESSAGE-ID)] {65}
< Message-ID: <ea-mime-REDACTED@REDACTED.localdomain>
< 
< )
< A004 OK FETCH done
```

```
> A004 FETCH 1 (BODY[HEADER.FIELDS ("Message-ID")])
< * 1 FETCH (BODY[HEADER.FIELDS ("MESSAGE-ID")] {2}
< 
< )
< A004 OK FETCH done
```

The server in question is provided by mailo.com. I know this deviates from standard, but I can only guess if we send something stricter than expected then it's ok ?