### PR TITLE
imapclient: add Dial() for unencrypted connections

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -209,6 +209,15 @@ func NewStartTLS(conn net.Conn, options *Options) (*Client, error) {
 	return client, nil
 }
 
+// DialInsecure connects to an IMAP server without any encryption at all.
+func DialInsecure(address string, options *Options) (*Client, error) {
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	return New(conn, options), nil
+}
+
 // DialTLS connects to an IMAP server with implicit TLS.
 func DialTLS(address string, options *Options) (*Client, error) {
 	tlsConfig := options.tlsConfig()


### PR DESCRIPTION
I mean, I certainly don't _insist_ that this method should exist, but [something](https://lists.sr.ht/~sircmpwn/tokidoki-devel/patches/49675#%3C20240219172110.381134-1-contact@emersion.fr%3E-47) gave me the impression you might think so :wink: 