### PR TITLE
POC: rewrite imapnum with generic

### DIFF
--- a/internal/imapnum/numset_test.go
+++ b/internal/imapnum/numset_test.go
@@ -11,76 +11,76 @@ const max = ^uint32(0)
 func TestParseNumRange(t *testing.T) {
 	tests := []struct {
 		in  string
-		out Range
+		out Range[uint32]
 		ok  bool
 	}{
 		// Invalid number
-		{"", Range{}, false},
-		{" ", Range{}, false},
-		{"A", Range{}, false},
-		{"0", Range{}, false},
-		{" 1", Range{}, false},
-		{"1 ", Range{}, false},
-		{"*1", Range{}, false},
-		{"1*", Range{}, false},
-		{"-1", Range{}, false},
-		{"01", Range{}, false},
-		{"0x1", Range{}, false},
-		{"1 2", Range{}, false},
-		{"1,2", Range{}, false},
-		{"1.2", Range{}, false},
-		{"4294967296", Range{}, false},
+		{"", Range[uint32]{}, false},
+		{" ", Range[uint32]{}, false},
+		{"A", Range[uint32]{}, false},
+		{"0", Range[uint32]{}, false},
+		{" 1", Range[uint32]{}, false},
+		{"1 ", Range[uint32]{}, false},
+		{"*1", Range[uint32]{}, false},
+		{"1*", Range[uint32]{}, false},
+		{"-1", Range[uint32]{}, false},
+		{"01", Range[uint32]{}, false},
+		{"0x1", Range[uint32]{}, false},
+		{"1 2", Range[uint32]{}, false},
+		{"1,2", Range[uint32]{}, false},
+		{"1.2", Range[uint32]{}, false},
+		{"4294967296", Range[uint32]{}, false},
 
 		// Valid number
-		{"*", Range{0, 0}, true},
-		{"1", Range{1, 1}, true},
-		{"42", Range{42, 42}, true},
-		{"1000", Range{1000, 1000}, true},
-		{"4294967295", Range{max, max}, true},
+		{"*", Range[uint32]{0, 0}, true},
+		{"1", Range[uint32]{1, 1}, true},
+		{"42", Range[uint32]{42, 42}, true},
+		{"1000", Range[uint32]{1000, 1000}, true},
+		{"4294967295", Range[uint32]{max, max}, true},
 
 		// Invalid range
-		{":", Range{}, false},
-		{"*:", Range{}, false},
-		{":*", Range{}, false},
-		{"1:", Range{}, false},
-		{":1", Range{}, false},
-		{"0:0", Range{}, false},
-		{"0:*", Range{}, false},
-		{"0:1", Range{}, false},
-		{"1:0", Range{}, false},
-		{"1:2 ", Range{}, false},
-		{"1: 2", Range{}, false},
-		{"1:2:", Range{}, false},
-		{"1:2,", Range{}, false},
-		{"1:2:3", Range{}, false},
-		{"1:2,3", Range{}, false},
-		{"*:4294967296", Range{}, false},
-		{"0:4294967295", Range{}, false},
-		{"1:4294967296", Range{}, false},
-		{"4294967296:*", Range{}, false},
-		{"4294967295:0", Range{}, false},
-		{"4294967296:1", Range{}, false},
-		{"4294967295:4294967296", Range{}, false},
+		{":", Range[uint32]{}, false},
+		{"*:", Range[uint32]{}, false},
+		{":*", Range[uint32]{}, false},
+		{"1:", Range[uint32]{}, false},
+		{":1", Range[uint32]{}, false},
+		{"0:0", Range[uint32]{}, false},
+		{"0:*", Range[uint32]{}, false},
+		{"0:1", Range[uint32]{}, false},
+		{"1:0", Range[uint32]{}, false},
+		{"1:2 ", Range[uint32]{}, false},
+		{"1: 2", Range[uint32]{}, false},
+		{"1:2:", Range[uint32]{}, false},
+		{"1:2,", Range[uint32]{}, false},
+		{"1:2:3", Range[uint32]{}, false},
+		{"1:2,3", Range[uint32]{}, false},
+		{"*:4294967296", Range[uint32]{}, false},
+		{"0:4294967295", Range[uint32]{}, false},
+		{"1:4294967296", Range[uint32]{}, false},
+		{"4294967296:*", Range[uint32]{}, false},
+		{"4294967295:0", Range[uint32]{}, false},
+		{"4294967296:1", Range[uint32]{}, false},
+		{"4294967295:4294967296", Range[uint32]{}, false},
 
 		// Valid range
-		{"*:*", Range{0, 0}, true},
-		{"1:*", Range{1, 0}, true},
-		{"*:1", Range{1, 0}, true},
-		{"2:2", Range{2, 2}, true},
-		{"2:42", Range{2, 42}, true},
-		{"42:2", Range{2, 42}, true},
-		{"*:4294967294", Range{max - 1, 0}, true},
-		{"*:4294967295", Range{max, 0}, true},
-		{"4294967294:*", Range{max - 1, 0}, true},
-		{"4294967295:*", Range{max, 0}, true},
-		{"1:4294967294", Range{1, max - 1}, true},
-		{"1:4294967295", Range{1, max}, true},
-		{"4294967295:1000", Range{1000, max}, true},
-		{"4294967294:4294967295", Range{max - 1, max}, true},
-		{"4294967295:4294967295", Range{max, max}, true},
+		{"*:*", Range[uint32]{0, 0}, true},
+		{"1:*", Range[uint32]{1, 0}, true},
+		{"*:1", Range[uint32]{1, 0}, true},
+		{"2:2", Range[uint32]{2, 2}, true},
+		{"2:42", Range[uint32]{2, 42}, true},
+		{"42:2", Range[uint32]{2, 42}, true},
+		{"*:4294967294", Range[uint32]{max - 1, 0}, true},
+		{"*:4294967295", Range[uint32]{max, 0}, true},
+		{"4294967294:*", Range[uint32]{max - 1, 0}, true},
+		{"4294967295:*", Range[uint32]{max, 0}, true},
+		{"1:4294967294", Range[uint32]{1, max - 1}, true},
+		{"1:4294967295", Range[uint32]{1, max}, true},
+		{"4294967295:1000", Range[uint32]{1000, max}, true},
+		{"4294967294:4294967295", Range[uint32]{max - 1, max}, true},
+		{"4294967295:4294967295", Range[uint32]{max, max}, true},
 	}
 	for _, test := range tests {
-		out, err := parseNumRange(test.in)
+		out, err := parseNumRange[uint32](test.in)
 		if !test.ok {
 			if err == nil {
 				t.Errorf("parseSeq(%q) expected error; got %q", test.in, out)
@@ -143,7 +143,7 @@ func TestNumRangeContainsLess(t *testing.T) {
 		{"4:*", max, true, false},
 	}
 	for _, test := range tests {
-		s, err := parseNumRange(test.s)
+		s, err := parseNumRange[uint32](test.s)
 		if err != nil {
 			t.Errorf("parseSeq(%q) unexpected error; %v", test.s, err)
 			continue
@@ -340,12 +340,12 @@ func TestNumRangeMerge(T *testing.T) {
 		{"1:4294967295", "2:*", "1:*"},
 	}
 	for _, test := range tests {
-		s, err := parseNumRange(test.s)
+		s, err := parseNumRange[uint32](test.s)
 		if err != nil {
 			T.Errorf("parseSeq(%q) unexpected error; %v", test.s, err)
 			continue
 		}
-		t, err := parseNumRange(test.t)
+		t, err := parseNumRange[uint32](test.t)
 		if err != nil {
 			T.Errorf("parseSeq(%q) unexpected error; %v", test.t, err)
 			continue
@@ -366,7 +366,7 @@ func TestNumRangeMerge(T *testing.T) {
 	}
 }
 
-func checkNumSet(s Set, t *testing.T) {
+func checkNumSet(s Set[uint32], t *testing.T) {
 	n := len(s)
 	for i, v := range s {
 		if v.Start == 0 {
@@ -531,7 +531,7 @@ func TestNumSetInfo(t *testing.T) {
 		{"1,3:5,7,9,42,60:70,100:*", max, true},
 	}
 	for _, test := range tests {
-		s, _ := ParseSet(test.s)
+		s, _ := ParseSet[uint32](test.s)
 		checkNumSet(s, t)
 		if s.Contains(test.q) != test.contains {
 			t.Errorf("%q.Contains(%v) expected %v", test.s, test.q, test.contains)
@@ -673,7 +673,7 @@ func TestParseNumSet(t *testing.T) {
 	}
 	for _, test := range tests {
 		for i := 0; i < 100 && test.in != ""; i++ {
-			s, err := ParseSet(test.in)
+			s, err := ParseSet[uint32](test.in)
 			if err != nil {
 				t.Errorf("Add(%q) unexpected error; %v", test.in, err)
 				i = 100
@@ -692,24 +692,24 @@ func TestNumSetAddNumRangeSet(t *testing.T) {
 	type num []uint32
 	tests := []struct {
 		num num
-		rng Range
+		rng Range[uint32]
 		set string
 		out string
 	}{
-		{num{5}, Range{1, 3}, "1:2,5,7:13,15,17:*", "1:3,5,7:13,15,17:*"},
-		{num{5}, Range{3, 1}, "2:3,7:13,15,17:*", "1:3,5,7:13,15,17:*"},
+		{num{5}, Range[uint32]{1, 3}, "1:2,5,7:13,15,17:*", "1:3,5,7:13,15,17:*"},
+		{num{5}, Range[uint32]{3, 1}, "2:3,7:13,15,17:*", "1:3,5,7:13,15,17:*"},
 
-		{num{15}, Range{17, 0}, "1:3,5,7:13", "1:3,5,7:13,15,17:*"},
-		{num{15}, Range{0, 17}, "1:3,5,7:13", "1:3,5,7:13,15,17:*"},
+		{num{15}, Range[uint32]{17, 0}, "1:3,5,7:13", "1:3,5,7:13,15,17:*"},
+		{num{15}, Range[uint32]{0, 17}, "1:3,5,7:13", "1:3,5,7:13,15,17:*"},
 
-		{num{1, 3, 5, 7, 9, 11, 0}, Range{8, 13}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
-		{num{5, 1, 7, 3, 9, 0, 11}, Range{8, 13}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
-		{num{5, 1, 7, 3, 9, 0, 11}, Range{13, 8}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
+		{num{1, 3, 5, 7, 9, 11, 0}, Range[uint32]{8, 13}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
+		{num{5, 1, 7, 3, 9, 0, 11}, Range[uint32]{8, 13}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
+		{num{5, 1, 7, 3, 9, 0, 11}, Range[uint32]{13, 8}, "2,15,17:*", "1:3,5,7:13,15,17:*"},
 	}
 	for _, test := range tests {
-		other, _ := ParseSet(test.set)
+		other, _ := ParseSet[uint32](test.set)
 
-		var s Set
+		var s Set[uint32]
 		s.AddNum(test.num...)
 		checkNumSet(s, t)
 		s.AddRange(test.rng.Start, test.rng.Stop)

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -522,16 +522,20 @@ func (dec *Decoder) ExpectNumSet(kind NumKind, ptr *imap.NumSet) bool {
 	if !dec.Expect(dec.Func(&s, isNumSetChar), "sequence-set") {
 		return false
 	}
-	numSet, err := imapnum.ParseSet(s)
-	if err != nil {
-		return dec.returnErr(err)
-	}
 
 	switch kind {
 	case NumKindSeq:
-		*ptr = seqSetFromNumSet(numSet)
+		set, err := imapnum.ParseSet[uint32](s)
+		if err != nil {
+			return dec.returnErr(err)
+		}
+		*ptr = imap.SeqSet(set)
 	case NumKindUID:
-		*ptr = uidSetFromNumSet(numSet)
+		set, err := imapnum.ParseSet[imap.UID](s)
+		if err != nil {
+			return dec.returnErr(err)
+		}
+		*ptr = imap.UIDSet(set)
 	}
 	return true
 }

--- a/internal/imapwire/num.go
+++ b/internal/imapwire/num.go
@@ -1,8 +1,6 @@
 package imapwire
 
 import (
-	"unsafe"
-
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/internal/imapnum"
 )
@@ -13,14 +11,6 @@ const (
 	NumKindSeq NumKind = iota + 1
 	NumKindUID
 )
-
-func seqSetFromNumSet(s imapnum.Set) imap.SeqSet {
-	return *(*imap.SeqSet)(unsafe.Pointer(&s))
-}
-
-func uidSetFromNumSet(s imapnum.Set) imap.UIDSet {
-	return *(*imap.UIDSet)(unsafe.Pointer(&s))
-}
 
 func NumSetKind(numSet imap.NumSet) NumKind {
 	switch numSet.(type) {
@@ -34,6 +24,5 @@ func NumSetKind(numSet imap.NumSet) NumKind {
 }
 
 func ParseSeqSet(s string) (imap.SeqSet, error) {
-	numSet, err := imapnum.ParseSet(s)
-	return seqSetFromNumSet(numSet), err
+	return imapnum.ParseSet[uint32](s)
 }

--- a/internal/imapwire/num.go
+++ b/internal/imapwire/num.go
@@ -24,5 +24,9 @@ func NumSetKind(numSet imap.NumSet) NumKind {
 }
 
 func ParseSeqSet(s string) (imap.SeqSet, error) {
-	return imapnum.ParseSet[uint32](s)
+	set, err := imapnum.ParseSet[uint32](s)
+	if err != nil {
+		return nil, err
+	}
+	return imap.SeqSet(set), nil
 }

--- a/numset.go
+++ b/numset.go
@@ -20,13 +20,47 @@ var (
 )
 
 // SeqSet is a set of message sequence numbers.
-type SeqSet = imapnum.Set[uint32]
+type SeqSet imapnum.Set[uint32]
 
 // SeqSetNum returns a new SeqSet containing the specified sequence numbers.
 func SeqSetNum(nums ...uint32) SeqSet {
 	var s SeqSet
 	s.AddNum(nums...)
 	return s
+}
+
+func (s SeqSet) String() string {
+	return imapnum.Set[uint32](s).String()
+}
+
+// Dynamic returns true if the set contains "*" or "n:*" values.
+func (s SeqSet) Dynamic() bool {
+	return imapnum.Set[uint32](s).Dynamic()
+}
+
+// Contains returns true if the non-zero sequence number is contained in the set.
+func (s SeqSet) Contains(uid uint32) bool {
+	return imapnum.Set[uint32](s).Contains(uid)
+}
+
+// Nums returns a slice of all sequence numbers contained in the set.
+func (s SeqSet) Nums() ([]uint32, bool) {
+	return imapnum.Set[uint32](s).Nums()
+}
+
+// AddNum inserts new sequence numbers into the set. The value 0 represents "*".
+func (s *SeqSet) AddNum(uids ...uint32) {
+	(*imapnum.Set[uint32])(s).AddNum(uids...)
+}
+
+// AddRange inserts a new range into the set.
+func (s *SeqSet) AddRange(start, stop uint32) {
+	(*imapnum.Set[uint32])(s).AddRange(start, stop)
+}
+
+// AddSet inserts all sequence numbers from other into s.
+func (s *SeqSet) AddSet(other SeqSet) {
+	(*imapnum.Set[uint32])(s).AddSet(imapnum.Set[uint32](other))
 }
 
 // SeqRange is a range of message sequence numbers.
@@ -54,7 +88,7 @@ func (s UIDSet) Dynamic() bool {
 	return imapnum.Set[UID](s).Dynamic() || IsSearchRes(s)
 }
 
-// Contains returns true if the non-zero UID uid is contained in the set.
+// Contains returns true if the non-zero UID is contained in the set.
 func (s UIDSet) Contains(uid UID) bool {
 	return imapnum.Set[UID](s).Contains(uid)
 }

--- a/numset.go
+++ b/numset.go
@@ -1,8 +1,6 @@
 package imap
 
 import (
-	"unsafe"
-
 	"github.com/emersion/go-imap/v2/internal/imapnum"
 )
 
@@ -14,8 +12,6 @@ type NumSet interface {
 	// Dynamic returns true if the set contains "*" or "n:*" ranges or if the
 	// set represents the special SEARCHRES marker.
 	Dynamic() bool
-
-	numSet() imapnum.Set
 }
 
 var (
@@ -24,7 +20,7 @@ var (
 )
 
 // SeqSet is a set of message sequence numbers.
-type SeqSet []SeqRange
+type SeqSet = imapnum.Set[uint32]
 
 // SeqSetNum returns a new SeqSet containing the specified sequence numbers.
 func SeqSetNum(nums ...uint32) SeqSet {
@@ -33,55 +29,11 @@ func SeqSetNum(nums ...uint32) SeqSet {
 	return s
 }
 
-func (s *SeqSet) numSetPtr() *imapnum.Set {
-	return (*imapnum.Set)(unsafe.Pointer(s))
-}
-
-func (s SeqSet) numSet() imapnum.Set {
-	return *s.numSetPtr()
-}
-
-func (s SeqSet) String() string {
-	return s.numSet().String()
-}
-
-func (s SeqSet) Dynamic() bool {
-	return s.numSet().Dynamic()
-}
-
-// Contains returns true if the non-zero sequence number num is contained in
-// the set.
-func (s *SeqSet) Contains(num uint32) bool {
-	return s.numSet().Contains(num)
-}
-
-// Nums returns a slice of all sequence numbers contained in the set.
-func (s *SeqSet) Nums() ([]uint32, bool) {
-	return s.numSet().Nums()
-}
-
-// AddNum inserts new sequence numbers into the set. The value 0 represents "*".
-func (s *SeqSet) AddNum(nums ...uint32) {
-	s.numSetPtr().AddNum(nums...)
-}
-
-// AddRange inserts a new range into the set.
-func (s *SeqSet) AddRange(start, stop uint32) {
-	s.numSetPtr().AddRange(start, stop)
-}
-
-// AddSet inserts all sequence numbers from other into s.
-func (s *SeqSet) AddSet(other SeqSet) {
-	s.numSetPtr().AddSet(other.numSet())
-}
-
 // SeqRange is a range of message sequence numbers.
-type SeqRange struct {
-	Start, Stop uint32
-}
+type SeqRange = imapnum.Range[uint32]
 
 // UIDSet is a set of message UIDs.
-type UIDSet []UIDRange
+type UIDSet imapnum.Set[UID]
 
 // UIDSetNum returns a new UIDSet containing the specified UIDs.
 func UIDSetNum(uids ...UID) UIDSet {
@@ -90,60 +42,42 @@ func UIDSetNum(uids ...UID) UIDSet {
 	return s
 }
 
-func (s *UIDSet) numSetPtr() *imapnum.Set {
-	return (*imapnum.Set)(unsafe.Pointer(s))
-}
-
-func (s UIDSet) numSet() imapnum.Set {
-	return *s.numSetPtr()
-}
-
 func (s UIDSet) String() string {
 	if IsSearchRes(s) {
 		return "$"
 	}
-	return s.numSet().String()
+	return imapnum.Set[UID](s).String()
 }
 
+// Dynamic returns true if the set contains "*" or "n:*" values.
 func (s UIDSet) Dynamic() bool {
-	return s.numSet().Dynamic() || IsSearchRes(s)
+	return imapnum.Set[UID](s).Dynamic() || IsSearchRes(s)
 }
 
 // Contains returns true if the non-zero UID uid is contained in the set.
 func (s UIDSet) Contains(uid UID) bool {
-	return s.numSet().Contains(uint32(uid))
+	return imapnum.Set[UID](s).Contains(uid)
 }
 
 // Nums returns a slice of all UIDs contained in the set.
 func (s UIDSet) Nums() ([]UID, bool) {
-	nums, ok := s.numSet().Nums()
-	return uidListFromNumList(nums), ok
+	return imapnum.Set[UID](s).Nums()
 }
 
 // AddNum inserts new UIDs into the set. The value 0 represents "*".
 func (s *UIDSet) AddNum(uids ...UID) {
-	s.numSetPtr().AddNum(numListFromUIDList(uids)...)
+	(*imapnum.Set[UID])(s).AddNum(uids...)
 }
 
 // AddRange inserts a new range into the set.
 func (s *UIDSet) AddRange(start, stop UID) {
-	s.numSetPtr().AddRange(uint32(start), uint32(stop))
+	(*imapnum.Set[UID])(s).AddRange(start, stop)
 }
 
 // AddSet inserts all UIDs from other into s.
 func (s *UIDSet) AddSet(other UIDSet) {
-	s.numSetPtr().AddSet(other.numSet())
+	(*imapnum.Set[UID])(s).AddSet(imapnum.Set[UID](other))
 }
 
 // UIDRange is a range of message UIDs.
-type UIDRange struct {
-	Start, Stop UID
-}
-
-func numListFromUIDList(uids []UID) []uint32 {
-	return *(*[]uint32)(unsafe.Pointer(&uids))
-}
-
-func uidListFromNumList(nums []uint32) []UID {
-	return *(*[]UID)(unsafe.Pointer(&nums))
-}
+type UIDRange = imapnum.Range[UID]


### PR DESCRIPTION
This is a POC to rewrite the `imapnum` package with generics.

Benifits:

1. no need to covert from/to numset with "unsafe" package

	```go
	(*imapnum.Set)(unsafe.Pointer(s))
	```
1. no need to code methods for each type if we don't override them
	```go
	// all methods are implemented in the generic type
	type SeqSet = imapnum.Set[uint32]
	```
1. no need to covert results of `Nums()` when override
	original:
    ```go
    func (s UIDSet) Nums() ([]UID, bool) {
		nums, ok := s.numSet().Nums()
		return uidListFromNumList(nums), ok
	}
	```
	with generic:
    ```go
	func (s UIDSet) Nums() ([]UID, bool) {
		return imapnum.Set[UID](s).Nums()
	}
	```