### PR TITLE
compatible with non-compliant responses with excessive SPACE

### DIFF
--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -135,7 +135,13 @@ func (dec *Decoder) Expect(ok bool, name string) bool {
 
 func (dec *Decoder) SP() bool {
 	if dec.acceptByte(' ') {
-		return true
+		// https://github.com/emersion/go-imap/issues/571
+		b, ok := dec.readByte()
+		if !ok {
+			return false
+		}
+		dec.mustUnreadByte()
+		return b != '\r' && b != '\n'
 	}
 
 	// Special case: SP is optional if the next field is a parenthesized list


### PR DESCRIPTION
This PR improves compatibility with non-compliant servers, by skipping excessive SPACE between elements and the trailing SPACE

- imap.exmail.qq.com: `* CAPABILITY IMAP4<SP>IMAP4rev1<SP><CRLF>`
- smtp-n.global-mail.cn: `* SEARCH<SP><CRLF>`

It works good in my env, the only question that comes to mind is whether `SP()`,  `ExpectSP()` needs to be renamed (e.g.: `LSP()` for leading Space) for method semantics reasons.

related: #571 #540