### PR TITLE
imapclient: Enhancement - Add custom interval to IDLE command

### DIFF
--- a/imapclient/idle.go
+++ b/imapclient/idle.go
@@ -115,6 +115,9 @@ func (cmd *IdleCommand) runWithInterval(c *Client, child *idleCommand, restartIn
 			if cmd.err = child.Close(); cmd.err != nil {
 				return
 			}
+			if cmd.err = child.Wait(); cmd.err != nil {
+				return
+			}
 			if child, cmd.err = c.idle(); cmd.err != nil {
 				return
 			}

--- a/imapclient/idle.go
+++ b/imapclient/idle.go
@@ -110,7 +110,7 @@ func (cmd *IdleCommand) runWithInterval(c *Client, child *idleCommand, restartIn
 	for {
 		select {
 		case <-timer.C:
-			timer.Reset(idleRestartInterval)
+			timer.Reset(*restartInterval)
 
 			if cmd.err = child.Close(); cmd.err != nil {
 				return


### PR DESCRIPTION
Although RFC states an IDLE timeout of 29 minutes, many IMAP servers timeout much earlier than that. Other forums point to around 10-13 minutes as a 'sweet spot'.

This PR gives more flexibility for those who need to adjust the restart interval. This also resolves issue #602 