### PR TITLE
v1: Fix connection hang

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -629,6 +629,10 @@ type Dialer interface {
 //
 // Among other uses, this allows to apply a dial timeout.
 func DialWithDialer(dialer Dialer, addr string) (*Client, error) {
+	return DialWithDialerAndTimeout(dialer, addr, 0)
+}
+
+func DialWithDialerAndTimeout(dialer Dialer, addr string, timeout time.Duration) (*Client, error) {
 	conn, err := dialer.Dial("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -638,13 +642,16 @@ func DialWithDialer(dialer Dialer, addr string) (*Client, error) {
 	// there is no way to set the client's Timeout for that action. As a
 	// workaround, if the dialer has a timeout set, use that for the connection's
 	// deadline.
-	var timeout time.Duration
-	if netDialer, ok := dialer.(*net.Dialer); ok && netDialer.Timeout > 0 {
-		err := conn.SetDeadline(time.Now().Add(netDialer.Timeout))
+	if timeout == 0 {
+		if netDialer, ok := dialer.(*net.Dialer); ok && netDialer.Timeout > 0 {
+			timeout = netDialer.Timeout
+		}
+	}
+	if timeout > 0 {
+		err = conn.SetDeadline(time.Now().Add(timeout))
 		if err != nil {
 			return nil, err
 		}
-		timeout = netDialer.Timeout
 	}
 
 	c, err := NewWithTimeout(conn, timeout)
@@ -666,6 +673,10 @@ func DialTLS(addr string, tlsConfig *tls.Config) (*Client, error) {
 //
 // Among other uses, this allows to apply a dial timeout.
 func DialWithDialerTLS(dialer Dialer, addr string, tlsConfig *tls.Config) (*Client, error) {
+	return DialWithDialerAndTimeoutTLS(dialer, addr, tlsConfig, 0)
+}
+
+func DialWithDialerAndTimeoutTLS(dialer Dialer, addr string, tlsConfig *tls.Config, timeout time.Duration) (*Client, error) {
 	conn, err := dialer.Dial("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -685,13 +696,16 @@ func DialWithDialerTLS(dialer Dialer, addr string, tlsConfig *tls.Config) (*Clie
 	// there is no way to set the client's Timeout for that action. As a
 	// workaround, if the dialer has a timeout set, use that for the connection's
 	// deadline.
-	var timeout time.Duration
-	if netDialer, ok := dialer.(*net.Dialer); ok && netDialer.Timeout > 0 {
-		err := tlsConn.SetDeadline(time.Now().Add(netDialer.Timeout))
+	if timeout == 0 {
+		if netDialer, ok := dialer.(*net.Dialer); ok && netDialer.Timeout > 0 {
+			timeout = netDialer.Timeout
+		}
+	}
+	if timeout > 0 {
+		err = conn.SetDeadline(time.Now().Add(timeout))
 		if err != nil {
 			return nil, err
 		}
-		timeout = netDialer.Timeout
 	}
 
 	c, err := NewWithTimeout(tlsConn, timeout)


### PR DESCRIPTION
This PR fixes the issue described in #611.

If the server does not respond to the `Support` calls in the New() function, the function blocks infinitely. Even if we supply a dialer with a timeout, there are 2 consequent `Support` calls. The first one runs with a deadline value but during the execution of the 2nd one, the deadline was set to the zero value. Setting the timeout value to the client is not enough because the client is not returned to the user yet.

I also added an optional timeout parameter to the `DialWithDialer` functions because callers may supply a Dialer that wraps the `net.Dialer`, which was our case.