### PR TITLE
Support complete section specification for BINARY, BINARY.PEEK, and BINARY.SIZE fetch data items

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -57,24 +57,37 @@ type SectionPartial struct {
 //
 //	imap.FetchItemBodySection{Specifier: imap.PartSpecifierHeader}
 type FetchItemBodySection struct {
+	Peek bool
+
+	Part []int
+
 	Specifier       PartSpecifier
-	Part            []int
 	HeaderFields    []string
 	HeaderFieldsNot []string
-	Partial         *SectionPartial
-	Peek            bool
+
+	Partial *SectionPartial
 }
 
 // FetchItemBinarySection is a FETCH BINARY[] data item.
 type FetchItemBinarySection struct {
-	Part    []int
+	Peek bool
+
+	Part []int
+
+	Specifier       PartSpecifier
+	HeaderFields    []string
+	HeaderFieldsNot []string
+
 	Partial *SectionPartial
-	Peek    bool
 }
 
 // FetchItemBinarySectionSize is a FETCH BINARY.SIZE[] data item.
 type FetchItemBinarySectionSize struct {
 	Part []int
+
+	Specifier       PartSpecifier
+	HeaderFields    []string
+	HeaderFieldsNot []string
 }
 
 // Envelope is the envelope structure of a message.


### PR DESCRIPTION
Added the same fetch section specification fields in the `imap.FetchItemBodySection` to the `imap.FetchItemBinarySection` and `imap.FetchItemBinarySectionSize` structs (allowed by the RFC9051):

```go
type FetchItemBodySection struct {
	Peek bool

	Part []int

	Specifier       PartSpecifier
	HeaderFields    []string
	HeaderFieldsNot []string

	Partial *SectionPartial
}

type FetchItemBinarySection struct {
	Peek bool

	Part []int

	Specifier       PartSpecifier // NEW
	HeaderFields    []string      // NEW
	HeaderFieldsNot []string      // NEW

	Partial *SectionPartial
}

type FetchItemBinarySectionSize struct {
	Part []int

	Specifier       PartSpecifier // NEW
	HeaderFields    []string      // NEW
	HeaderFieldsNot []string      // NEW
}
```

Then, did the cascading changes required in `imapclient` and `imapserver` to read and write those new fields; reused the fetch section specification read/write logic of `imap.FetchItemBodySection`, by defining a private `fetchSectionSpec` proxy struct.

I tried to make no major/breaking API changes, and that's why it may seem like a mess.