### PR TITLE
imapclient: add helpers to match FETCH response sections

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -236,6 +236,61 @@ func (cmd *FetchCommand) Collect() ([]*FetchMessageBuffer, error) {
 	return l, cmd.Close()
 }
 
+func matchFetchItemBodySection(cmd, resp *imap.FetchItemBodySection) bool {
+	if cmd.Specifier != resp.Specifier {
+		return false
+	}
+
+	if !intSliceEqual(cmd.Part, resp.Part) {
+		return false
+	}
+	if !stringSliceEqualFold(cmd.HeaderFields, resp.HeaderFields) {
+		return false
+	}
+	if !stringSliceEqualFold(cmd.HeaderFieldsNot, resp.HeaderFieldsNot) {
+		return false
+	}
+
+	if (cmd.Partial == nil) != (resp.Partial == nil) {
+		return false
+	}
+	if cmd.Partial != nil && cmd.Partial.Offset != resp.Partial.Offset {
+		return false
+	}
+
+	// Ignore Partial.Size and Peek: these are not echoed back by the server
+	return true
+}
+
+func matchFetchItemBinarySection(cmd, resp *imap.FetchItemBinarySection) bool {
+	// Ignore Partial and Peek: these are not echoed back by the server
+	return intSliceEqual(cmd.Part, resp.Part)
+}
+
+func intSliceEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSliceEqualFold(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // FetchMessageData contains a message's FETCH data.
 type FetchMessageData struct {
 	SeqNum uint32
@@ -328,6 +383,12 @@ func (item FetchItemDataBodySection) discard() {
 	}
 }
 
+// MatchCommand checks whether a section returned by the server in a response
+// is compatible with a section requested by the client in a command.
+func (dataItem *FetchItemDataBodySection) MatchCommand(item *imap.FetchItemBodySection) bool {
+	return matchFetchItemBodySection(item, dataItem.Section)
+}
+
 // FetchItemDataBinarySection holds data returned by FETCH BINARY[].
 //
 // Literal might be nil.
@@ -342,6 +403,12 @@ func (item FetchItemDataBinarySection) discard() {
 	if item.Literal != nil {
 		io.Copy(io.Discard, item.Literal)
 	}
+}
+
+// MatchCommand checks whether a section returned by the server in a response
+// is compatible with a section requested by the client in a command.
+func (dataItem *FetchItemDataBinarySection) MatchCommand(item *imap.FetchItemBinarySection) bool {
+	return matchFetchItemBinarySection(item, dataItem.Section)
 }
 
 // FetchItemDataFlags holds data returned by FETCH FLAGS.
@@ -395,6 +462,13 @@ type FetchItemDataBinarySectionSize struct {
 }
 
 func (FetchItemDataBinarySectionSize) fetchItemData() {}
+
+// MatchCommand checks whether a section size returned by the server in a
+// response is compatible with a section size requested by the client in a
+// command.
+func (data *FetchItemDataBinarySectionSize) MatchCommand(item *imap.FetchItemBinarySectionSize) bool {
+	return intSliceEqual(item.Part, data.Part)
+}
 
 // FetchItemDataModSeq holds data returned by FETCH MODSEQ.
 //
@@ -470,6 +544,42 @@ func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
 		panic(fmt.Errorf("unsupported fetch item data %T", item))
 	}
 	return nil
+}
+
+// FindBodySection returns the contents of a requested body section.
+//
+// If the body section is not found, nil is returned.
+func (buf *FetchMessageBuffer) FindBodySection(section *imap.FetchItemBodySection) []byte {
+	for s, b := range buf.BodySection {
+		if matchFetchItemBodySection(section, s) {
+			return b
+		}
+	}
+	return nil
+}
+
+// FindBinarySection returns the contents of a requested binary section.
+//
+// If the binary section is not found, nil is returned.
+func (buf *FetchMessageBuffer) FindBinarySection(section *imap.FetchItemBinarySection) []byte {
+	for s, b := range buf.BinarySection {
+		if matchFetchItemBinarySection(section, s) {
+			return b
+		}
+	}
+	return nil
+}
+
+// FindBinarySectionSize returns a requested binary section size.
+//
+// If the binary section size is not found, false is returned.
+func (buf *FetchMessageBuffer) FindBinarySectionSize(part []int) (uint32, bool) {
+	for _, s := range buf.BinarySectionSize {
+		if intSliceEqual(part, s.Part) {
+			return s.Size, true
+		}
+	}
+	return 0, false
 }
 
 func (c *Client) handleFetch(seqNum uint32) error {

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -479,6 +479,20 @@ type FetchItemDataModSeq struct {
 
 func (FetchItemDataModSeq) fetchItemData() {}
 
+// FetchBodySectionBuffer is a buffer for the data returned by
+// FetchItemBodySection.
+type FetchBodySectionBuffer struct {
+	Section *imap.FetchItemBodySection
+	Bytes   []byte
+}
+
+// FetchBinarySectionBuffer is a buffer for the data returned by
+// FetchItemBinarySection.
+type FetchBinarySectionBuffer struct {
+	Section *imap.FetchItemBinarySection
+	Bytes   []byte
+}
+
 // FetchMessageBuffer is a buffer for the data returned by FetchMessageData.
 //
 // The SeqNum field is always populated. All remaining fields are optional.
@@ -490,8 +504,8 @@ type FetchMessageBuffer struct {
 	RFC822Size        int64
 	UID               imap.UID
 	BodyStructure     imap.BodyStructure
-	BodySection       map[*imap.FetchItemBodySection][]byte
-	BinarySection     map[*imap.FetchItemBinarySection][]byte
+	BodySection       []FetchBodySectionBuffer
+	BinarySection     []FetchBinarySectionBuffer
 	BinarySectionSize []FetchItemDataBinarySectionSize
 	ModSeq            uint64 // requires CONDSTORE
 }
@@ -507,10 +521,10 @@ func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
 				return err
 			}
 		}
-		if buf.BodySection == nil {
-			buf.BodySection = make(map[*imap.FetchItemBodySection][]byte)
-		}
-		buf.BodySection[item.Section] = b
+		buf.BodySection = append(buf.BodySection, FetchBodySectionBuffer{
+			Section: item.Section,
+			Bytes:   b,
+		})
 	case FetchItemDataBinarySection:
 		var b []byte
 		if item.Literal != nil {
@@ -520,10 +534,10 @@ func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
 				return err
 			}
 		}
-		if buf.BinarySection == nil {
-			buf.BinarySection = make(map[*imap.FetchItemBinarySection][]byte)
-		}
-		buf.BinarySection[item.Section] = b
+		buf.BinarySection = append(buf.BinarySection, FetchBinarySectionBuffer{
+			Section: item.Section,
+			Bytes:   b,
+		})
 	case FetchItemDataFlags:
 		buf.Flags = item.Flags
 	case FetchItemDataEnvelope:
@@ -550,9 +564,9 @@ func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
 //
 // If the body section is not found, nil is returned.
 func (buf *FetchMessageBuffer) FindBodySection(section *imap.FetchItemBodySection) []byte {
-	for s, b := range buf.BodySection {
-		if matchFetchItemBodySection(section, s) {
-			return b
+	for _, s := range buf.BodySection {
+		if matchFetchItemBodySection(section, s.Section) {
+			return s.Bytes
 		}
 	}
 	return nil
@@ -562,9 +576,9 @@ func (buf *FetchMessageBuffer) FindBodySection(section *imap.FetchItemBodySectio
 //
 // If the binary section is not found, nil is returned.
 func (buf *FetchMessageBuffer) FindBinarySection(section *imap.FetchItemBinarySection) []byte {
-	for s, b := range buf.BinarySection {
-		if matchFetchItemBinarySection(section, s) {
-			return b
+	for _, s := range buf.BinarySection {
+		if matchFetchItemBinarySection(section, s.Section) {
+			return s.Bytes
 		}
 	}
 	return nil

--- a/imapclient/fetch_test.go
+++ b/imapclient/fetch_test.go
@@ -13,8 +13,9 @@ func TestFetch(t *testing.T) {
 	defer server.Close()
 
 	seqSet := imap.SeqSetNum(1)
+	bodySection := &imap.FetchItemBodySection{}
 	fetchOptions := &imap.FetchOptions{
-		BodySection: []*imap.FetchItemBodySection{{}},
+		BodySection: []*imap.FetchItemBodySection{bodySection},
 	}
 	messages, err := client.Fetch(seqSet, fetchOptions).Collect()
 	if err != nil {
@@ -27,10 +28,11 @@ func TestFetch(t *testing.T) {
 	if len(msg.BodySection) != 1 {
 		t.Fatalf("len(msg.BodySection) = %v, want 1", len(msg.BodySection))
 	}
-	var body string
-	for _, b := range msg.BodySection {
-		body = strings.ReplaceAll(string(b), "\r\n", "\n")
+	b := msg.FindBodySection(bodySection)
+	if b == nil {
+		t.Fatalf("FindBodySection() = nil")
 	}
+	body := strings.ReplaceAll(string(b), "\r\n", "\n")
 	if body != simpleRawMessage {
 		t.Errorf("body mismatch: got \n%v\n but want \n%v", body, simpleRawMessage)
 	}


### PR DESCRIPTION
- [x] Consider not using `map` in `FetchMessageBuffer`