### PR TITLE
Allow special characters in unquoted mailbox names

### DIFF
--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -399,8 +399,9 @@ func (dec *Decoder) ExpectAString(ptr *string) bool {
 	if dec.Literal(ptr) {
 		return true
 	}
-	// TODO: accept unquoted resp-specials
-	return dec.ExpectAtom(ptr)
+	// We cannot do dec.Atom(ptr) here because sometimes mailbox names are unquoted,
+	// and they can contain special characters like `]`.
+	return dec.ExpectText(ptr)
 }
 
 func (dec *Decoder) String(ptr *string) bool {

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -27,9 +27,9 @@ func IsAtomChar(ch byte) bool {
 }
 
 // Is non-empty char
-func IsNonEmptyChar(ch byte) bool {
+func IsNonEmptyOrParenthesisChar(ch byte) bool {
 	switch ch {
-	case ' ', '\r', '\n':
+	case ' ', '\r', '\n', '(', ')':
 		return false
 	default:
 		return !unicode.IsControl(rune(ch))
@@ -211,12 +211,12 @@ func (dec *Decoder) ExpectAtom(ptr *string) bool {
 	return dec.Expect(dec.Atom(ptr), "atom")
 }
 
-func (dec *Decoder) NonEmpty(ptr *string) bool {
-	return dec.Func(ptr, IsNonEmptyChar)
+func (dec *Decoder) NonEmptyOrParenthesis(ptr *string) bool {
+	return dec.Func(ptr, IsNonEmptyOrParenthesisChar)
 }
 
-func (dec *Decoder) ExpectNonEmpty(ptr *string) bool {
-	return dec.Expect(dec.NonEmpty(ptr), "non-empty")
+func (dec *Decoder) ExpectNonEmptyOrParenthesis(ptr *string) bool {
+	return dec.Expect(dec.NonEmptyOrParenthesis(ptr), "non-empty")
 }
 
 func (dec *Decoder) ExpectNIL() bool {
@@ -419,7 +419,7 @@ func (dec *Decoder) ExpectAString(ptr *string) bool {
 	}
 	// We cannot do dec.Atom(ptr) here because sometimes mailbox names are unquoted,
 	// and they can contain special characters like `]`.
-	return dec.ExpectNonEmpty(ptr)
+	return dec.ExpectNonEmptyOrParenthesis(ptr)
 }
 
 func (dec *Decoder) String(ptr *string) bool {

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -29,10 +28,7 @@ func IsAtomChar(ch byte) bool {
 
 // Is non-empty char
 func isAStringChar(ch byte) bool {
-	if slices.Contains([]byte{']', '%', '*'}, ch) {
-		return true
-	}
-	return IsAtomChar(ch)
+	return IsAtomChar(ch) || ch == ']'
 }
 
 // DecoderExpectError is an error due to the Decoder.Expect family of methods.

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -27,13 +28,11 @@ func IsAtomChar(ch byte) bool {
 }
 
 // Is non-empty char
-func IsNonEmptyOrParenthesisChar(ch byte) bool {
-	switch ch {
-	case ' ', '\r', '\n', '(', ')':
-		return false
-	default:
-		return !unicode.IsControl(rune(ch))
+func isAStringChar(ch byte) bool {
+	if slices.Contains([]byte{']', '%', '*'}, ch) {
+		return true
 	}
+	return IsAtomChar(ch)
 }
 
 // DecoderExpectError is an error due to the Decoder.Expect family of methods.
@@ -209,14 +208,6 @@ func (dec *Decoder) Atom(ptr *string) bool {
 
 func (dec *Decoder) ExpectAtom(ptr *string) bool {
 	return dec.Expect(dec.Atom(ptr), "atom")
-}
-
-func (dec *Decoder) NonEmptyOrParenthesis(ptr *string) bool {
-	return dec.Func(ptr, IsNonEmptyOrParenthesisChar)
-}
-
-func (dec *Decoder) ExpectNonEmptyOrParenthesis(ptr *string) bool {
-	return dec.Expect(dec.NonEmptyOrParenthesis(ptr), "non-empty")
 }
 
 func (dec *Decoder) ExpectNIL() bool {
@@ -419,7 +410,7 @@ func (dec *Decoder) ExpectAString(ptr *string) bool {
 	}
 	// We cannot do dec.Atom(ptr) here because sometimes mailbox names are unquoted,
 	// and they can contain special characters like `]`.
-	return dec.ExpectNonEmptyOrParenthesis(ptr)
+	return dec.Expect(dec.Func(ptr, isAStringChar), "ASTRING-CHAR")
 }
 
 func (dec *Decoder) String(ptr *string) bool {

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -26,6 +26,16 @@ func IsAtomChar(ch byte) bool {
 	}
 }
 
+// Is non-empty char
+func IsNonEmptyChar(ch byte) bool {
+	switch ch {
+	case ' ', '\r', '\n':
+		return false
+	default:
+		return !unicode.IsControl(rune(ch))
+	}
+}
+
 // DecoderExpectError is an error due to the Decoder.Expect family of methods.
 type DecoderExpectError struct {
 	Message string
@@ -199,6 +209,14 @@ func (dec *Decoder) Atom(ptr *string) bool {
 
 func (dec *Decoder) ExpectAtom(ptr *string) bool {
 	return dec.Expect(dec.Atom(ptr), "atom")
+}
+
+func (dec *Decoder) NonEmpty(ptr *string) bool {
+	return dec.Func(ptr, IsNonEmptyChar)
+}
+
+func (dec *Decoder) ExpectNonEmpty(ptr *string) bool {
+	return dec.Expect(dec.NonEmpty(ptr), "non-empty")
 }
 
 func (dec *Decoder) ExpectNIL() bool {
@@ -401,7 +419,7 @@ func (dec *Decoder) ExpectAString(ptr *string) bool {
 	}
 	// We cannot do dec.Atom(ptr) here because sometimes mailbox names are unquoted,
 	// and they can contain special characters like `]`.
-	return dec.ExpectText(ptr)
+	return dec.ExpectNonEmpty(ptr)
 }
 
 func (dec *Decoder) String(ptr *string) bool {


### PR DESCRIPTION
Hi @emersion ,

Can I make this change to allow special character in unquoted mailbox names? IMAP providers such as StartMail does that.

I created an issue here: https://github.com/emersion/go-imap/issues/639. Then I found out may be we can do this change to solve the problem. Do you think my change is sufficient?

I used a startmail account to create a bunch of folders with special characters, and then verified my changes. It is working. Here is the related output while using `DebugWriter: os.Stdout` option:

```
T2 LIST "" "*"
* LIST (\HasNoChildren) "." Special#Hash
* LIST (\HasNoChildren) "." "Special%Percentage"
* LIST (\HasNoChildren) "." "(Parenthesis)"
* LIST (\HasNoChildren \Marked) "." [Special]
* LIST (\HasNoChildren \UnMarked \Sent) "." "Sent Messages"
* LIST (\HasNoChildren \UnMarked \Trash) "." "Deleted Messages"
* LIST (\HasNoChildren \UnMarked \Junk) "." Junk
* LIST (\HasNoChildren \UnMarked \Drafts) "." Drafts
* LIST (\HasNoChildren) "." INBOX
T2 OK List completed (0.001 + 0.000 secs).
```

Zhi Qu