### PR TITLE
imapclient: avoid leaking cmd.Wait method

### DIFF
--- a/imapclient/acl.go
+++ b/imapclient/acl.go
@@ -33,11 +33,11 @@ func (c *Client) SetACL(mailbox string, ri imap.RightsIdentifier, rm imap.RightM
 
 // SetACLCommand is a SETACL command.
 type SetACLCommand struct {
-	cmd
+	commandBase
 }
 
 func (cmd *SetACLCommand) Wait() error {
-	return cmd.cmd.Wait()
+	return cmd.wait()
 }
 
 // GetACL sends a GETACL command.
@@ -53,12 +53,12 @@ func (c *Client) GetACL(mailbox string) *GetACLCommand {
 
 // GetACLCommand is a GETACL command.
 type GetACLCommand struct {
-	cmd
+	commandBase
 	data GetACLData
 }
 
 func (cmd *GetACLCommand) Wait() (*GetACLData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 func (c *Client) handleMyRights() error {
@@ -85,12 +85,12 @@ func (c *Client) handleGetACL() error {
 
 // MyRightsCommand is a MYRIGHTS command.
 type MyRightsCommand struct {
-	cmd
+	commandBase
 	data MyRightsData
 }
 
 func (cmd *MyRightsCommand) Wait() (*MyRightsData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 // MyRightsData is the data returned by the MYRIGHTS command.

--- a/imapclient/append.go
+++ b/imapclient/append.go
@@ -34,7 +34,7 @@ func (c *Client) Append(mailbox string, size int64, options *imap.AppendOptions)
 //
 // Callers must write the message contents, then call Close.
 type AppendCommand struct {
-	cmd
+	commandBase
 	enc  *commandEncoder
 	wc   io.WriteCloser
 	data imap.AppendData
@@ -54,5 +54,5 @@ func (cmd *AppendCommand) Close() error {
 }
 
 func (cmd *AppendCommand) Wait() (*imap.AppendData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }

--- a/imapclient/authenticate.go
+++ b/imapclient/authenticate.go
@@ -38,7 +38,7 @@ func (c *Client) Authenticate(saslClient sasl.Client) error {
 	for {
 		challengeStr, err := contReq.Wait()
 		if err != nil {
-			return cmd.Wait()
+			return cmd.wait()
 		}
 
 		if challengeStr == "" {
@@ -72,7 +72,7 @@ func (c *Client) Authenticate(saslClient sasl.Client) error {
 }
 
 type authenticateCommand struct {
-	cmd
+	commandBase
 }
 
 func (c *Client) writeSASLResp(resp []byte) error {
@@ -92,9 +92,9 @@ func (c *Client) writeSASLResp(resp []byte) error {
 func (c *Client) Unauthenticate() *Command {
 	cmd := &unauthenticateCommand{}
 	c.beginCommand("UNAUTHENTICATE", cmd).end()
-	return &cmd.cmd
+	return &cmd.Command
 }
 
 type unauthenticateCommand struct {
-	cmd
+	Command
 }

--- a/imapclient/capability.go
+++ b/imapclient/capability.go
@@ -28,12 +28,12 @@ func (c *Client) handleCapability() error {
 
 // CapabilityCommand is a CAPABILITY command.
 type CapabilityCommand struct {
-	cmd
+	commandBase
 	caps imap.CapSet
 }
 
 func (cmd *CapabilityCommand) Wait() (imap.CapSet, error) {
-	err := cmd.cmd.Wait()
+	err := cmd.wait()
 	return cmd.caps, err
 }
 

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -404,7 +404,7 @@ func (c *Client) beginCommand(name string, cmd command) *commandEncoder {
 	tag := fmt.Sprintf("T%v", c.cmdTag)
 
 	baseCmd := cmd.base()
-	*baseCmd = Command{
+	*baseCmd = commandBase{
 		tag:  tag,
 		done: make(chan error, 1),
 	}
@@ -1017,7 +1017,7 @@ func (c *Client) Noop() *Command {
 func (c *Client) Logout() *Command {
 	cmd := &logoutCommand{}
 	c.beginCommand("LOGOUT", cmd).end()
-	return &cmd.cmd
+	return &cmd.Command
 }
 
 // Login sends a LOGIN command.
@@ -1026,7 +1026,7 @@ func (c *Client) Login(username, password string) *Command {
 	enc := c.beginCommand("LOGIN", cmd)
 	enc.SP().String(username).SP().String(password)
 	enc.end()
-	return &cmd.cmd
+	return &cmd.Command
 }
 
 // Delete sends a DELETE command.
@@ -1079,7 +1079,7 @@ func uidCmdName(name string, kind imapwire.NumKind) string {
 type commandEncoder struct {
 	*imapwire.Encoder
 	client *Client
-	cmd    *Command
+	cmd    *commandBase
 }
 
 // end ends an outgoing command.
@@ -1135,7 +1135,7 @@ func (lw literalWriter) Close() error {
 // continuationRequest is a pending continuation request.
 type continuationRequest struct {
 	*imapwire.ContinuationRequest
-	cmd *Command
+	cmd *commandBase
 }
 
 // UnilateralDataMailbox describes a mailbox status update.
@@ -1170,35 +1170,41 @@ type UnilateralDataHandler struct {
 // Commands are represented by the Command type, but can be extended by other
 // types (e.g. CapabilityCommand).
 type command interface {
-	base() *Command
+	base() *commandBase
 }
 
-// Command is a basic IMAP command.
-type Command struct {
+type commandBase struct {
 	tag  string
 	done chan error
 	err  error
 }
 
-func (cmd *Command) base() *Command {
+func (cmd *commandBase) base() *commandBase {
 	return cmd
 }
 
-// Wait blocks until the command has completed.
-func (cmd *Command) Wait() error {
+func (cmd *commandBase) wait() error {
 	if cmd.err == nil {
 		cmd.err = <-cmd.done
 	}
 	return cmd.err
 }
 
-type cmd = Command // type alias to avoid exporting anonymous struct fields
+// Command is a basic IMAP command.
+type Command struct {
+	commandBase
+}
+
+// Wait blocks until the command has completed.
+func (cmd *Command) Wait() error {
+	return cmd.wait()
+}
 
 type loginCommand struct {
-	cmd
+	Command
 }
 
 // logoutCommand is a LOGOUT command.
 type logoutCommand struct {
-	cmd
+	Command
 }

--- a/imapclient/copy.go
+++ b/imapclient/copy.go
@@ -18,12 +18,12 @@ func (c *Client) Copy(numSet imap.NumSet, mailbox string) *CopyCommand {
 
 // CopyCommand is a COPY command.
 type CopyCommand struct {
-	cmd
+	commandBase
 	data imap.CopyData
 }
 
 func (cmd *CopyCommand) Wait() (*imap.CopyData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 func readRespCodeCopyUID(dec *imapwire.Decoder) (uidValidity uint32, srcUIDs, dstUIDs imap.UIDSet, err error) {

--- a/imapclient/enable.go
+++ b/imapclient/enable.go
@@ -20,7 +20,7 @@ func (c *Client) Enable(caps ...imap.Cap) *EnableCommand {
 			done := make(chan error)
 			close(done)
 			err := fmt.Errorf("imapclient: cannot enable %q: not supported", name)
-			return &EnableCommand{cmd: Command{done: done, err: err}}
+			return &EnableCommand{commandBase: commandBase{done: done, err: err}}
 		}
 	}
 
@@ -54,12 +54,12 @@ func (c *Client) handleEnabled() error {
 
 // EnableCommand is an ENABLE command.
 type EnableCommand struct {
-	cmd
+	commandBase
 	data EnableData
 }
 
 func (cmd *EnableCommand) Wait() (*EnableData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 // EnableData is the data returned by the ENABLE command.

--- a/imapclient/expunge.go
+++ b/imapclient/expunge.go
@@ -45,7 +45,7 @@ func (c *Client) handleExpunge(seqNum uint32) error {
 // The caller must fully consume the ExpungeCommand. A simple way to do so is
 // to defer a call to FetchCommand.Close.
 type ExpungeCommand struct {
-	cmd
+	commandBase
 	seqNums chan uint32
 }
 
@@ -65,7 +65,7 @@ func (cmd *ExpungeCommand) Close() error {
 	for cmd.Next() != 0 {
 		// ignore
 	}
-	return cmd.cmd.Wait()
+	return cmd.wait()
 }
 
 // Collect accumulates expunged sequence numbers into a list.

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -148,7 +148,7 @@ func writeSectionPartial(enc *imapwire.Encoder, partial *imap.SectionPartial) {
 
 // FetchCommand is a FETCH command.
 type FetchCommand struct {
-	cmd
+	commandBase
 
 	numSet     imap.NumSet
 	recvSeqSet imap.SeqSet
@@ -206,7 +206,7 @@ func (cmd *FetchCommand) Close() error {
 	for cmd.Next() != nil {
 		// ignore
 	}
-	return cmd.cmd.Wait()
+	return cmd.wait()
 }
 
 // Collect accumulates message data into a list.

--- a/imapclient/id.go
+++ b/imapclient/id.go
@@ -154,10 +154,10 @@ func (c *Client) readID(dec *imapwire.Decoder) (*imap.IDData, error) {
 }
 
 type IDCommand struct {
-	cmd
+	commandBase
 	data imap.IDData
 }
 
 func (r *IDCommand) Wait() (*imap.IDData, error) {
-	return &r.data, r.cmd.Wait()
+	return &r.data, r.wait()
 }

--- a/imapclient/idle.go
+++ b/imapclient/idle.go
@@ -121,7 +121,7 @@ func (c *Client) idle() (*idleCommand, error) {
 
 // idleCommand represents a singular IDLE command, without the restart logic.
 type idleCommand struct {
-	cmd
+	commandBase
 	enc *commandEncoder
 }
 
@@ -153,5 +153,5 @@ func (cmd *idleCommand) Wait() error {
 	if cmd.enc != nil {
 		panic("imapclient: idleCommand.Close must be called before Wait")
 	}
-	return cmd.cmd.Wait()
+	return cmd.wait()
 }

--- a/imapclient/list.go
+++ b/imapclient/list.go
@@ -124,7 +124,7 @@ func (c *Client) handleList() error {
 
 // ListCommand is a LIST command.
 type ListCommand struct {
-	cmd
+	commandBase
 	mailboxes chan *imap.ListData
 
 	returnStatus bool
@@ -147,7 +147,7 @@ func (cmd *ListCommand) Close() error {
 	for cmd.Next() != nil {
 		// ignore
 	}
-	return cmd.cmd.Wait()
+	return cmd.wait()
 }
 
 // Collect accumulates mailboxes into a list.

--- a/imapclient/metadata.go
+++ b/imapclient/metadata.go
@@ -132,13 +132,13 @@ func (c *Client) handleMetadata() error {
 
 // GetMetadataCommand is a GETMETADATA command.
 type GetMetadataCommand struct {
-	cmd
+	commandBase
 	mailbox string
 	data    GetMetadataData
 }
 
 func (cmd *GetMetadataCommand) Wait() (*GetMetadataData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 // GetMetadataData is the data returned by the GETMETADATA command.

--- a/imapclient/move.go
+++ b/imapclient/move.go
@@ -40,7 +40,7 @@ func (c *Client) Move(numSet imap.NumSet, mailbox string) *MoveCommand {
 
 // MoveCommand is a MOVE command.
 type MoveCommand struct {
-	cmd
+	commandBase
 	data MoveData
 
 	// Fallback
@@ -49,7 +49,7 @@ type MoveCommand struct {
 }
 
 func (cmd *MoveCommand) Wait() (*MoveData, error) {
-	if err := cmd.cmd.Wait(); err != nil {
+	if err := cmd.wait(); err != nil {
 		return nil, err
 	}
 	if cmd.store != nil {

--- a/imapclient/namespace.go
+++ b/imapclient/namespace.go
@@ -29,12 +29,12 @@ func (c *Client) handleNamespace() error {
 
 // NamespaceCommand is a NAMESPACE command.
 type NamespaceCommand struct {
-	cmd
+	commandBase
 	data imap.NamespaceData
 }
 
 func (cmd *NamespaceCommand) Wait() (*imap.NamespaceData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 func readNamespaceResponse(dec *imapwire.Decoder) (*imap.NamespaceData, error) {

--- a/imapclient/quota.go
+++ b/imapclient/quota.go
@@ -102,13 +102,13 @@ func (c *Client) handleQuotaRoot() error {
 
 // GetQuotaCommand is a GETQUOTA command.
 type GetQuotaCommand struct {
-	cmd
+	commandBase
 	root string
 	data *QuotaData
 }
 
 func (cmd *GetQuotaCommand) Wait() (*QuotaData, error) {
-	if err := cmd.cmd.Wait(); err != nil {
+	if err := cmd.wait(); err != nil {
 		return nil, err
 	}
 	return cmd.data, nil
@@ -116,14 +116,14 @@ func (cmd *GetQuotaCommand) Wait() (*QuotaData, error) {
 
 // GetQuotaRootCommand is a GETQUOTAROOT command.
 type GetQuotaRootCommand struct {
-	cmd
+	commandBase
 	mailbox string
 	roots   []string
 	data    []QuotaData
 }
 
 func (cmd *GetQuotaRootCommand) Wait() ([]QuotaData, error) {
-	if err := cmd.cmd.Wait(); err != nil {
+	if err := cmd.wait(); err != nil {
 		return nil, err
 	}
 	return cmd.data, nil

--- a/imapclient/search.go
+++ b/imapclient/search.go
@@ -148,12 +148,12 @@ func (c *Client) handleESearch() error {
 
 // SearchCommand is a SEARCH command.
 type SearchCommand struct {
-	cmd
+	commandBase
 	data imap.SearchData
 }
 
 func (cmd *SearchCommand) Wait() (*imap.SearchData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 func writeSearchKey(enc *imapwire.Encoder, criteria *imap.SearchCriteria) {

--- a/imapclient/select.go
+++ b/imapclient/select.go
@@ -30,7 +30,7 @@ func (c *Client) Select(mailbox string, options *imap.SelectOptions) *SelectComm
 func (c *Client) Unselect() *Command {
 	cmd := &unselectCommand{}
 	c.beginCommand("UNSELECT", cmd).end()
-	return &cmd.cmd
+	return &cmd.Command
 }
 
 // UnselectAndExpunge sends a CLOSE command.
@@ -39,7 +39,7 @@ func (c *Client) Unselect() *Command {
 func (c *Client) UnselectAndExpunge() *Command {
 	cmd := &unselectCommand{}
 	c.beginCommand("CLOSE", cmd).end()
-	return &cmd.cmd
+	return &cmd.Command
 }
 
 func (c *Client) handleFlags() error {
@@ -86,15 +86,15 @@ func (c *Client) handleExists(num uint32) error {
 
 // SelectCommand is a SELECT command.
 type SelectCommand struct {
-	cmd
+	commandBase
 	mailbox string
 	data    imap.SelectData
 }
 
 func (cmd *SelectCommand) Wait() (*imap.SelectData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 type unselectCommand struct {
-	cmd
+	Command
 }

--- a/imapclient/sort.go
+++ b/imapclient/sort.go
@@ -74,11 +74,11 @@ func (c *Client) UIDSort(options *SortOptions) *SortCommand {
 
 // SortCommand is a SORT command.
 type SortCommand struct {
-	cmd
+	commandBase
 	nums []uint32
 }
 
 func (cmd *SortCommand) Wait() ([]uint32, error) {
-	err := cmd.cmd.Wait()
+	err := cmd.wait()
 	return cmd.nums, err
 }

--- a/imapclient/starttls.go
+++ b/imapclient/starttls.go
@@ -25,7 +25,7 @@ func (c *Client) startTLS(config *tls.Config) error {
 	// commands until a server response is seen and the TLS negotiation is
 	// complete
 
-	if err := cmd.Wait(); err != nil {
+	if err := cmd.wait(); err != nil {
 		return err
 	}
 
@@ -66,7 +66,7 @@ func (c *Client) upgradeStartTLS(startTLS *startTLSCommand) {
 }
 
 type startTLSCommand struct {
-	cmd
+	commandBase
 	tlsConfig *tls.Config
 
 	upgradeDone chan<- struct{}

--- a/imapclient/status.go
+++ b/imapclient/status.go
@@ -79,13 +79,13 @@ func (c *Client) handleStatus() error {
 
 // StatusCommand is a STATUS command.
 type StatusCommand struct {
-	cmd
+	commandBase
 	mailbox string
 	data    imap.StatusData
 }
 
 func (cmd *StatusCommand) Wait() (*imap.StatusData, error) {
-	return &cmd.data, cmd.cmd.Wait()
+	return &cmd.data, cmd.wait()
 }
 
 func readStatus(dec *imapwire.Decoder) (*imap.StatusData, error) {

--- a/imapclient/thread.go
+++ b/imapclient/thread.go
@@ -52,12 +52,12 @@ func (c *Client) handleThread() error {
 
 // ThreadCommand is a THREAD command.
 type ThreadCommand struct {
-	cmd
+	commandBase
 	data []ThreadData
 }
 
 func (cmd *ThreadCommand) Wait() ([]ThreadData, error) {
-	err := cmd.cmd.Wait()
+	err := cmd.wait()
 	return cmd.data, err
 }
 


### PR DESCRIPTION
All commands embed a base struct previously called "cmd". The "cmd" type exports a Wait method, intended to be used for simple commands which don't return any additional data. Typical usage:

    type MyCommand {
        cmd
    }

Unfortunately, even if "cmd" is an unexported field, its Wait method is accessible to other packages. This causes issues for commands which need to read a bunch of untagged responses before completing.

Fix this by rejiggering the command types. Introduce a baseCommand type which is embedded in all command types and doesn't export any method. Add a Command type which exposes a single Wait method for simple commands.

Closes: https://github.com/emersion/go-imap/issues/641