### PR TITLE
Allow continuous SP for all commands

### DIFF
--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -140,6 +140,8 @@ func (dec *Decoder) Expect(ok bool, name string) bool {
 
 func (dec *Decoder) SP() bool {
 	if dec.acceptByte(' ') {
+		for dec.acceptByte(' ') {
+		}
 		// https://github.com/emersion/go-imap/issues/571
 		b, ok := dec.readByte()
 		if !ok {
@@ -163,7 +165,8 @@ func (dec *Decoder) ExpectSP() bool {
 }
 
 func (dec *Decoder) CRLF() bool {
-	dec.acceptByte(' ')  // https://github.com/emersion/go-imap/issues/540
+	for dec.acceptByte(' ') {
+	} // https://github.com/emersion/go-imap/issues/540
 	dec.acceptByte('\r') // be liberal in what we receive and accept lone LF
 	if !dec.acceptByte('\n') {
 		return false


### PR DESCRIPTION
Before logged in, imap-n.global-mail.cn sends:

    * CAPABILITY IMAP4<...>LITERAL+<SP><SP>STARTTLS<...>SPECIAL-USE