### PR TITLE
imapserver: add support for RFC822.PEEK

### DIFF
--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -112,6 +112,10 @@ func handleFetchAtt(dec *imapwire.Decoder, attName string, options *imap.FetchOp
 		bs := &imap.FetchItemBodySection{}
 		writerOptions.obsolete[bs] = attName
 		options.BodySection = append(options.BodySection, bs)
+	case "RFC822.PEEK": // obsolete, equivalent to BODY.PEEK[], used by Outlook
+		bs := &imap.FetchItemBodySection{Peek: true}
+		writerOptions.obsolete[bs] = attName
+		options.BodySection = append(options.BodySection, bs)
 	case "RFC822.HEADER": // equivalent to BODY.PEEK[HEADER]
 		bs := &imap.FetchItemBodySection{
 			Specifier: imap.PartSpecifierHeader,


### PR DESCRIPTION
This is still used by Outlook:
https://learn.microsoft.com/en-us/openspecs/exchange_standards/ms-stanoimap/8e9492b1-b812-4a1a-93ea-4d69489eb5cd

Closes: https://github.com/emersion/go-imap/issues/657