### PR TITLE
imapserver: include partial offset in BINARY FETCH response

### DIFF
--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -433,7 +433,11 @@ func (w *FetchResponseWriter) WriteBinarySection(section *imap.FetchItemBinarySe
 
 	enc.Atom("BINARY").Special('[')
 	writeSectionPart(enc, section.Part)
-	enc.Special(']').SP()
+	enc.Special(']')
+	if partial := section.Partial; partial != nil {
+		enc.Special('<').Number(uint32(partial.Offset)).Special('>')
+	}
+	enc.SP()
 	enc.Special('~') // indicates literal8
 	return w.enc.Literal(size)
 }


### PR DESCRIPTION
See https://www.rfc-editor.org/errata/eid8217