### PR TITLE
imapserver: Support RECENT for IMAP4rev1 servers

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -107,6 +107,14 @@ func (set CapSet) has(c Cap) bool {
 	return ok
 }
 
+func (set CapSet) Copy() CapSet {
+	newSet := make(CapSet, len(set))
+	for c := range set {
+		newSet[c] = struct{}{}
+	}
+	return newSet
+}
+
 // Has checks whether a capability is supported.
 //
 // Some capabilities are implied by others, as such Has may return true even if

--- a/imapclient/status.go
+++ b/imapclient/status.go
@@ -37,6 +37,9 @@ func (c *Client) Status(mailbox string, options *imap.StatusOptions) *StatusComm
 	if options == nil {
 		options = new(imap.StatusOptions)
 	}
+	if options.NumRecent {
+		panic("StatusOptions.NumRecent is not supported in imapclient")
+	}
 
 	cmd := &StatusCommand{mailbox: mailbox}
 	enc := c.beginCommand("STATUS", cmd)

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -85,6 +85,13 @@ func (c *Conn) Bye(text string) error {
 	return closeErr
 }
 
+func (c *Conn) EnabledCaps() imap.CapSet {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.enabled.Copy()
+}
+
 func (c *Conn) serve() {
 	defer func() {
 		if v := recover(); v != nil {
@@ -583,6 +590,14 @@ func (w *UpdateWriter) WriteExpunge(seqNum uint32) error {
 // WriteNumMessages writes an EXISTS response.
 func (w *UpdateWriter) WriteNumMessages(n uint32) error {
 	return w.conn.writeExists(n)
+}
+
+// WriteNumRecent writes an RECENT response (not used in IMAP4rev2, will be ignored).
+func (w *UpdateWriter) WriteNumRecent(n uint32) error {
+	if w.conn.enabled.Has(imap.CapIMAP4rev2) || !w.conn.server.options.caps().Has(imap.CapIMAP4rev1) {
+		return nil
+	}
+	return w.conn.writeObsoleteRecent(n)
 }
 
 // WriteMailboxFlags writes a FLAGS response.

--- a/imapserver/list.go
+++ b/imapserver/list.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (c *Conn) handleList(dec *imapwire.Decoder) error {
-	ref, pattern, options, returnRecent, err := readListCmd(dec)
+	ref, pattern, options, err := readListCmd(dec)
 	if err != nil {
 		return err
 	}
@@ -20,9 +20,8 @@ func (c *Conn) handleList(dec *imapwire.Decoder) error {
 	}
 
 	w := &ListWriter{
-		conn:         c,
-		options:      options,
-		returnRecent: returnRecent,
+		conn:    c,
+		options: options,
 	}
 	return c.session.List(w, ref, pattern, options)
 }
@@ -117,11 +116,11 @@ func (c *Conn) writeLSub(data *imap.ListData) error {
 	return enc.CRLF()
 }
 
-func readListCmd(dec *imapwire.Decoder) (ref string, patterns []string, options *imap.ListOptions, returnRecent bool, err error) {
+func readListCmd(dec *imapwire.Decoder) (ref string, patterns []string, options *imap.ListOptions, err error) {
 	options = &imap.ListOptions{}
 
 	if !dec.ExpectSP() {
-		return "", nil, nil, false, dec.Err()
+		return "", nil, nil, dec.Err()
 	}
 
 	hasSelectOpts, err := dec.List(func() error {
@@ -142,14 +141,14 @@ func readListCmd(dec *imapwire.Decoder) (ref string, patterns []string, options 
 		return nil
 	})
 	if err != nil {
-		return "", nil, nil, false, fmt.Errorf("in list-select-opts: %w", err)
+		return "", nil, nil, fmt.Errorf("in list-select-opts: %w", err)
 	}
 	if hasSelectOpts && !dec.ExpectSP() {
-		return "", nil, nil, false, dec.Err()
+		return "", nil, nil, dec.Err()
 	}
 
 	if !dec.ExpectMailbox(&ref) || !dec.ExpectSP() {
-		return "", nil, nil, false, dec.Err()
+		return "", nil, nil, dec.Err()
 	}
 
 	hasPatterns, err := dec.List(func() error {
@@ -160,13 +159,13 @@ func readListCmd(dec *imapwire.Decoder) (ref string, patterns []string, options 
 		return err
 	})
 	if err != nil {
-		return "", nil, nil, false, err
+		return "", nil, nil, err
 	} else if hasPatterns && len(patterns) == 0 {
-		return "", nil, nil, false, newClientBugError("LIST-EXTENDED requires a non-empty parenthesized pattern list")
+		return "", nil, nil, newClientBugError("LIST-EXTENDED requires a non-empty parenthesized pattern list")
 	} else if !hasPatterns {
 		pattern, err := readListMailbox(dec)
 		if err != nil {
-			return "", nil, nil, false, err
+			return "", nil, nil, err
 		}
 		if pattern != "" {
 			patterns = append(patterns, pattern)
@@ -176,26 +175,26 @@ func readListCmd(dec *imapwire.Decoder) (ref string, patterns []string, options 
 	if dec.SP() { // list-return-opts
 		var atom string
 		if !dec.ExpectAtom(&atom) || !dec.Expect(strings.EqualFold(atom, "RETURN"), "RETURN") || !dec.ExpectSP() {
-			return "", nil, nil, false, dec.Err()
+			return "", nil, nil, dec.Err()
 		}
 
 		err := dec.ExpectList(func() error {
-			return readReturnOption(dec, options, &returnRecent)
+			return readReturnOption(dec, options)
 		})
 		if err != nil {
-			return "", nil, nil, false, fmt.Errorf("in list-return-opts: %w", err)
+			return "", nil, nil, fmt.Errorf("in list-return-opts: %w", err)
 		}
 	}
 
 	if !dec.ExpectCRLF() {
-		return "", nil, nil, false, dec.Err()
+		return "", nil, nil, dec.Err()
 	}
 
 	if options.SelectRecursiveMatch && !options.SelectSubscribed {
-		return "", nil, nil, false, newClientBugError("The LIST RECURSIVEMATCH select option requires SUBSCRIBED")
+		return "", nil, nil, newClientBugError("The LIST RECURSIVEMATCH select option requires SUBSCRIBED")
 	}
 
-	return ref, patterns, options, returnRecent, nil
+	return ref, patterns, options, nil
 }
 
 func readListMailbox(dec *imapwire.Decoder) (string, error) {
@@ -219,7 +218,7 @@ func isListChar(ch byte) bool {
 	}
 }
 
-func readReturnOption(dec *imapwire.Decoder, options *imap.ListOptions, recent *bool) error {
+func readReturnOption(dec *imapwire.Decoder, options *imap.ListOptions) error {
 	var name string
 	if !dec.ExpectAtom(&name) {
 		return dec.Err()
@@ -236,11 +235,7 @@ func readReturnOption(dec *imapwire.Decoder, options *imap.ListOptions, recent *
 		}
 		options.ReturnStatus = new(imap.StatusOptions)
 		return dec.ExpectList(func() error {
-			isRecent, err := readStatusItem(dec, options.ReturnStatus)
-			if isRecent {
-				*recent = true
-			}
-			return err
+			return readStatusItem(dec, options.ReturnStatus)
 		})
 	default:
 		return newClientBugError("Unknown LIST RETURN options")
@@ -250,10 +245,9 @@ func readReturnOption(dec *imapwire.Decoder, options *imap.ListOptions, recent *
 
 // ListWriter writes LIST responses.
 type ListWriter struct {
-	conn         *Conn
-	options      *imap.ListOptions
-	returnRecent bool
-	lsub         bool
+	conn    *Conn
+	options *imap.ListOptions
+	lsub    bool
 }
 
 // WriteList writes a single LIST response for a mailbox.
@@ -266,7 +260,7 @@ func (w *ListWriter) WriteList(data *imap.ListData) error {
 		return err
 	}
 	if w.options.ReturnStatus != nil && data.Status != nil {
-		if err := w.conn.writeStatus(data.Status, w.options.ReturnStatus, w.returnRecent); err != nil {
+		if err := w.conn.writeStatus(data.Status, w.options.ReturnStatus); err != nil {
 			return err
 		}
 	}

--- a/imapserver/select.go
+++ b/imapserver/select.go
@@ -42,7 +42,7 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 		return err
 	}
 	if !c.enabled.Has(imap.CapIMAP4rev2) {
-		if err := c.writeObsoleteRecent(); err != nil {
+		if err := c.writeObsoleteRecent(data.NumRecent); err != nil {
 			return err
 		}
 	}
@@ -115,10 +115,10 @@ func (c *Conn) writeExists(numMessages uint32) error {
 	return enc.Atom("*").SP().Number(numMessages).SP().Atom("EXISTS").CRLF()
 }
 
-func (c *Conn) writeObsoleteRecent() error {
+func (c *Conn) writeObsoleteRecent(n uint32) error {
 	enc := newResponseEncoder(c)
 	defer enc.end()
-	return enc.Atom("*").SP().Number(0).SP().Atom("RECENT").CRLF()
+	return enc.Atom("*").SP().Number(n).SP().Atom("RECENT").CRLF()
 }
 
 func (c *Conn) writeUIDValidity(uidValidity uint32) error {

--- a/imapserver/status.go
+++ b/imapserver/status.go
@@ -14,13 +14,10 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 	}
 
 	var options imap.StatusOptions
-	recent := false
 	err := dec.ExpectList(func() error {
-		isRecent, err := readStatusItem(dec, &options)
+		err := readStatusItem(dec, &options)
 		if err != nil {
 			return err
-		} else if isRecent {
-			recent = true
 		}
 		return nil
 	})
@@ -32,6 +29,13 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 		return dec.Err()
 	}
 
+	if options.NumRecent && !c.server.options.caps().Has(imap.CapIMAP4rev1) {
+		return &imap.Error{
+			Type: imap.StatusResponseTypeBad,
+			Text: "Unknown STATUS data item",
+		}
+	}
+
 	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
 		return err
 	}
@@ -41,10 +45,10 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 		return err
 	}
 
-	return c.writeStatus(data, &options, recent)
+	return c.writeStatus(data, &options)
 }
 
-func (c *Conn) writeStatus(data *imap.StatusData, options *imap.StatusOptions, recent bool) error {
+func (c *Conn) writeStatus(data *imap.StatusData, options *imap.StatusOptions) error {
 	enc := newResponseEncoder(c)
 	defer enc.end()
 
@@ -79,18 +83,18 @@ func (c *Conn) writeStatus(data *imap.StatusData, options *imap.StatusOptions, r
 	if options.DeletedStorage {
 		listEnc.Item().Atom("DELETED-STORAGE").SP().Number64(*data.DeletedStorage)
 	}
-	if recent {
-		listEnc.Item().Atom("RECENT").SP().Number(0)
+	if options.NumRecent {
+		listEnc.Item().Atom("RECENT").SP().Number(*data.NumRecent)
 	}
 	listEnc.End()
 
 	return enc.CRLF()
 }
 
-func readStatusItem(dec *imapwire.Decoder, options *imap.StatusOptions) (isRecent bool, err error) {
+func readStatusItem(dec *imapwire.Decoder, options *imap.StatusOptions) error {
 	var name string
 	if !dec.ExpectAtom(&name) {
-		return false, dec.Err()
+		return dec.Err()
 	}
 	switch strings.ToUpper(name) {
 	case "MESSAGES":
@@ -110,12 +114,12 @@ func readStatusItem(dec *imapwire.Decoder, options *imap.StatusOptions) (isRecen
 	case "DELETED-STORAGE":
 		options.DeletedStorage = true
 	case "RECENT":
-		isRecent = true
+		options.NumRecent = true
 	default:
-		return false, &imap.Error{
+		return &imap.Error{
 			Type: imap.StatusResponseTypeBad,
 			Text: "Unknown STATUS data item",
 		}
 	}
-	return isRecent, nil
+	return nil
 }

--- a/select.go
+++ b/select.go
@@ -16,6 +16,9 @@ type SelectData struct {
 	PermanentFlags []Flag
 	// Number of messages in this mailbox (aka. "EXISTS")
 	NumMessages uint32
+	// Number of recent messages in this mailbox ("RECENT") (Obsolete, IMAP4rev1 only).
+	// Server-only, not supported in imapclient.
+	NumRecent   uint32
 	UIDNext     UID
 	UIDValidity uint32
 

--- a/status.go
+++ b/status.go
@@ -3,6 +3,7 @@ package imap
 // StatusOptions contains options for the STATUS command.
 type StatusOptions struct {
 	NumMessages bool
+	NumRecent   bool // Obsolete, IMAP4rev1 only. Server-only, not supported in imapclient.
 	UIDNext     bool
 	UIDValidity bool
 	NumUnseen   bool
@@ -21,6 +22,7 @@ type StatusData struct {
 	Mailbox string
 
 	NumMessages *uint32
+	NumRecent   *uint32 // Obsolete, IMAP4rev1 only. Server-only, not supported in imapclient.
 	UIDNext     UID
 	UIDValidity uint32
 	NumUnseen   *uint32


### PR DESCRIPTION
`\Recent` flag is used by several IMAP4rev1 clients including Thunderbird and aerc.

1. STATUS data item: RECENT.
2. SELECT untagged response: RECENT.
3. Removed hacks that add `RECENTS 0` responses.
4. Conn.IsEnabled(Cap) method

I added Conn.IsEnabled method for checking whether a certain extension is enabled. This can be used by backend implementations to disable/enable (potentially expensive) RECENT handling if IMAP4rev2 is in use.