### PR TITLE
fixes for fetches 

### DIFF
--- a/imapserver/copy.go
+++ b/imapserver/copy.go
@@ -13,7 +13,7 @@ func (c *Conn) handleCopy(tag string, dec *imapwire.Decoder, numKind NumKind) er
 	if err := c.checkState(imap.ConnStateSelected); err != nil {
 		return err
 	}
-	data, err := c.session.Copy(numSet, dest)
+	data, err := c.session.Copy(numSet, numKind, dest)
 	if err != nil {
 		return err
 	}

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -88,7 +88,7 @@ func (c *Conn) handleFetch(dec *imapwire.Decoder, numKind NumKind) error {
 	}
 
 	w := &FetchWriter{conn: c, options: writerOptions}
-	if err := c.session.Fetch(w, numSet, &options); err != nil {
+	if err := c.session.Fetch(w, numSet, numKind, &options); err != nil {
 		return err
 	}
 	return nil

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -491,6 +491,12 @@ func (w *FetchResponseWriter) writeBodyStructure(bs imap.BodyStructure, extended
 	writeBodyStructure(enc, bs, extended)
 }
 
+// WriteModSeq writes the message's mod-sequence.
+func (w *FetchResponseWriter) WriteModSeq(modseq uint64) {
+	w.writeItemSep()
+	w.enc.Atom("MODSEQ").SP().Special('(').String(fmt.Sprintf("%d", modseq)).Special(')')
+}
+
 // Close closes the FETCH message writer.
 func (w *FetchResponseWriter) Close() error {
 	if w.enc == nil {

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -558,7 +558,7 @@ func writeEnvelope(enc *imapwire.Encoder, envelope *imap.Envelope) {
 }
 
 func writeAddressList(enc *imapwire.Encoder, l []imap.Address) {
-	if l == nil {
+	if len(l) == 0 {
 		enc.NIL()
 		return
 	}
@@ -677,7 +677,7 @@ func writeBodyTypeMpart(enc *imapwire.Encoder, bs *imap.BodyStructureMultiPart, 
 }
 
 func writeBodyFldParam(enc *imapwire.Encoder, params map[string]string) {
-	if params == nil {
+	if len(params) == 0 {
 		enc.NIL()
 		return
 	}
@@ -707,7 +707,7 @@ func writeBodyFldDsp(enc *imapwire.Encoder, disp *imap.BodyStructureDisposition)
 }
 
 func writeBodyFldLang(enc *imapwire.Encoder, l []string) {
-	if l == nil {
+	if len(l) == 0 {
 		enc.NIL()
 	} else {
 		enc.List(len(l), func(i int) {

--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -283,7 +283,7 @@ func (mbox *MailboxView) Close() {
 	mbox.tracker.Close()
 }
 
-func (mbox *MailboxView) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error {
+func (mbox *MailboxView) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, numKind imapserver.NumKind, options *imap.FetchOptions) error {
 	markSeen := false
 	for _, bs := range options.BodySection {
 		if !bs.Peek {
@@ -392,13 +392,13 @@ func (mbox *MailboxView) staticSearchCriteria(criteria *imap.SearchCriteria) {
 	}
 }
 
-func (mbox *MailboxView) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error {
+func (mbox *MailboxView) Store(w *imapserver.FetchWriter, numSet imap.NumSet, numKind imapserver.NumKind, flags *imap.StoreFlags, options *imap.StoreOptions) error {
 	mbox.forEach(numSet, func(seqNum uint32, msg *message) {
 		msg.store(flags)
 		mbox.Mailbox.tracker.QueueMessageFlags(seqNum, msg.uid, msg.flagList(), mbox.tracker)
 	})
 	if !flags.Silent {
-		return mbox.Fetch(w, numSet, &imap.FetchOptions{Flags: true})
+		return mbox.Fetch(w, numSet, numKind, &imap.FetchOptions{Flags: true})
 	}
 	return nil
 }

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -50,7 +50,7 @@ func (sess *UserSession) Unselect() error {
 	return nil
 }
 
-func (sess *UserSession) Copy(numSet imap.NumSet, destName string) (*imap.CopyData, error) {
+func (sess *UserSession) Copy(numSet imap.NumSet, numKind imapserver.NumKind, destName string) (*imap.CopyData, error) {
 	dest, err := sess.user.mailbox(destName)
 	if err != nil {
 		return nil, &imap.Error{
@@ -79,7 +79,7 @@ func (sess *UserSession) Copy(numSet imap.NumSet, destName string) (*imap.CopyDa
 	}, nil
 }
 
-func (sess *UserSession) Move(w *imapserver.MoveWriter, numSet imap.NumSet, destName string) error {
+func (sess *UserSession) Move(w *imapserver.MoveWriter, numSet imap.NumSet, numKind imapserver.NumKind, destName string) error {
 	dest, err := sess.user.mailbox(destName)
 	if err != nil {
 		return &imap.Error{

--- a/imapserver/move.go
+++ b/imapserver/move.go
@@ -18,7 +18,7 @@ func (c *Conn) handleMove(dec *imapwire.Decoder, numKind NumKind) error {
 		return newClientBugError("MOVE is not supported")
 	}
 	w := &MoveWriter{conn: c}
-	return session.Move(w, numSet, dest)
+	return session.Move(w, numSet, numKind, dest)
 }
 
 // MoveWriter writes responses for the MOVE command.

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -71,9 +71,9 @@ type Session interface {
 	Unselect() error
 	Expunge(w *ExpungeWriter, uids *imap.UIDSet) error
 	Search(kind NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error)
-	Fetch(w *FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error
-	Store(w *FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error
-	Copy(numSet imap.NumSet, dest string) (*imap.CopyData, error)
+	Fetch(w *FetchWriter, numSet imap.NumSet, numKind NumKind, options *imap.FetchOptions) error
+	Store(w *FetchWriter, numSet imap.NumSet, numKind NumKind, flags *imap.StoreFlags, options *imap.StoreOptions) error
+	Copy(numSet imap.NumSet, numKind NumKind, dest string) (*imap.CopyData, error)
 }
 
 // SessionNamespace is an IMAP session which supports NAMESPACE.
@@ -89,7 +89,7 @@ type SessionMove interface {
 	Session
 
 	// Selected state
-	Move(w *MoveWriter, numSet imap.NumSet, dest string) error
+	Move(w *MoveWriter, numSet imap.NumSet, numKind NumKind, dest string) error
 }
 
 // SessionIMAP4rev2 is an IMAP session which supports IMAP4rev2.

--- a/imapserver/store.go
+++ b/imapserver/store.go
@@ -70,7 +70,7 @@ func (c *Conn) handleStore(dec *imapwire.Decoder, numKind NumKind) error {
 
 	w := &FetchWriter{conn: c}
 	options := imap.StoreOptions{}
-	return c.session.Store(w, numSet, &imap.StoreFlags{
+	return c.session.Store(w, numSet, numKind, &imap.StoreFlags{
 		Op:     op,
 		Silent: silent,
 		Flags:  flags,


### PR DESCRIPTION
- wherever numSet is passed in session methods, also numKind is needed so the call can be interpreted right
- in fetch, we need WriteModSeq if options.ModSeq is set
- empty lists were wrongly converted to () instead of NIL atom, e.g. resulting in `("image" "png" () "<logo>" NIL "BASE64" 3608 NIL ("inline" ()) NIL NIL)` instead of `("image" "png" NIL "<logo>" NIL "base64" 3608 NIL ("inline" NIL) NIL NIL)`
