### PR TITLE
Correct missing NIL atom instead of ()

### DIFF
--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -552,7 +552,7 @@ func writeEnvelope(enc *imapwire.Encoder, envelope *imap.Envelope) {
 }
 
 func writeAddressList(enc *imapwire.Encoder, l []imap.Address) {
-	if l == nil {
+	if len(l) == 0 {
 		enc.NIL()
 		return
 	}
@@ -671,7 +671,7 @@ func writeBodyTypeMpart(enc *imapwire.Encoder, bs *imap.BodyStructureMultiPart, 
 }
 
 func writeBodyFldParam(enc *imapwire.Encoder, params map[string]string) {
-	if params == nil {
+	if len(params) == 0 {
 		enc.NIL()
 		return
 	}
@@ -701,7 +701,7 @@ func writeBodyFldDsp(enc *imapwire.Encoder, disp *imap.BodyStructureDisposition)
 }
 
 func writeBodyFldLang(enc *imapwire.Encoder, l []string) {
-	if l == nil {
+	if len(l) == 0 {
 		enc.NIL()
 	} else {
 		enc.List(len(l), func(i int) {


### PR DESCRIPTION
empty lists were wrongly converted to () instead of NIL atom, e.g. resulting in `("image" "png" () "<logo>" NIL "BASE64" 3608 NIL ("inline" ()) NIL NIL)` instead of` ("image" "png" NIL "<logo>" NIL "base64" 3608 NIL ("inline" NIL) NIL NIL)`