### PR TITLE
ci: adapt dovecot config file to dovecot 2.4

### DIFF
--- a/imapclient/acl_test.go
+++ b/imapclient/acl_test.go
@@ -82,13 +82,13 @@ func TestACL(t *testing.T) {
 			// execute SETACL command
 			err := client.SetACL(tc.mailbox, testUsername, tc.setRightsModification, tc.setRights).Wait()
 			if err != nil {
-				t.Errorf("SetACL().Wait() error: %v", err)
+				t.Fatalf("SetACL().Wait() error: %v", err)
 			}
 
 			// execute GETACL command to reset cache on server
 			getACLData, err := client.GetACL(tc.mailbox).Wait()
 			if err != nil {
-				t.Errorf("GetACL().Wait() error: %v", err)
+				t.Fatalf("GetACL().Wait() error: %v", err)
 			}
 
 			if !tc.expectedRights.Equal(getACLData.Rights[testUsername]) {

--- a/imapclient/acl_test.go
+++ b/imapclient/acl_test.go
@@ -73,8 +73,8 @@ func TestACL(t *testing.T) {
 		t.Fatalf("create MyFolder error: %v", err)
 	}
 
-	if err := client.Create("MyFolder/Child", nil).Wait(); err != nil {
-		t.Fatalf("create MyFolder/Child error: %v", err)
+	if err := client.Create("MyFolder.Child", nil).Wait(); err != nil {
+		t.Fatalf("create MyFolder.Child error: %v", err)
 	}
 
 	for _, tc := range testCases {

--- a/imapclient/acl_test.go
+++ b/imapclient/acl_test.go
@@ -31,7 +31,7 @@ var testCases = []struct {
 	},
 	{
 		name:                  "custom_child_folder",
-		mailbox:               "MyFolder.Child",
+		mailbox:               "MyFolder/Child",
 		setRightsModification: imap.RightModificationReplace,
 		setRights:             imap.RightSet("aelrwtd"),
 		expectedRights:        imap.RightSet("aelrwtd"),
@@ -52,7 +52,7 @@ var testCases = []struct {
 	},
 	{
 		name:                  "empty_rights",
-		mailbox:               "MyFolder.Child",
+		mailbox:               "MyFolder/Child",
 		setRightsModification: imap.RightModificationReplace,
 		setRights:             imap.RightSet("a"),
 		expectedRights:        imap.RightSet("a"),

--- a/imapclient/acl_test.go
+++ b/imapclient/acl_test.go
@@ -73,8 +73,8 @@ func TestACL(t *testing.T) {
 		t.Fatalf("create MyFolder error: %v", err)
 	}
 
-	if err := client.Create("MyFolder.Child", nil).Wait(); err != nil {
-		t.Fatalf("create MyFolder.Child error: %v", err)
+	if err := client.Create("MyFolder/Child", nil).Wait(); err != nil {
+		t.Fatalf("create MyFolder/Child error: %v", err)
 	}
 
 	for _, tc := range testCases {

--- a/imapclient/dovecot_test.go
+++ b/imapclient/dovecot_test.go
@@ -14,6 +14,9 @@ func newDovecotClientServerPair(t *testing.T) (net.Conn, io.Closer) {
 
 	cfgFilename := filepath.Join(tempDir, "dovecot.conf")
 	cfg := `log_path      = "` + tempDir + `/dovecot.log"
+dovecot_config_version  = 2.4.0
+dovecot_storage_version = 2.4.0
+
 ssl           = no
 mail_home     = "` + tempDir + `/%u"
 mail_location = maildir:~/Mail

--- a/imapclient/dovecot_test.go
+++ b/imapclient/dovecot_test.go
@@ -18,8 +18,9 @@ dovecot_storage_version = 2.4.0
 
 log_path      = "` + tempDir + `/dovecot.log"
 ssl           = no
-mail_home     = "` + tempDir + `/%u"
-mail_location = maildir:~/Mail
+mail_home     = "` + tempDir + `/%{user}"
+mail_driver   = maildir
+mail_path     = "~/Mail"
 
 namespace inbox {
 	separator = /

--- a/imapclient/dovecot_test.go
+++ b/imapclient/dovecot_test.go
@@ -13,10 +13,10 @@ func newDovecotClientServerPair(t *testing.T) (net.Conn, io.Closer) {
 	tempDir := t.TempDir()
 
 	cfgFilename := filepath.Join(tempDir, "dovecot.conf")
-	cfg := `log_path      = "` + tempDir + `/dovecot.log"
-dovecot_config_version  = 2.4.0
+	cfg := `dovecot_config_version  = 2.4.0
 dovecot_storage_version = 2.4.0
 
+log_path      = "` + tempDir + `/dovecot.log"
 ssl           = no
 mail_home     = "` + tempDir + `/%u"
 mail_location = maildir:~/Mail

--- a/imapclient/dovecot_test.go
+++ b/imapclient/dovecot_test.go
@@ -28,13 +28,17 @@ namespace inbox {
 	inbox = yes
 }
 
-mail_plugins = $mail_plugins acl
+mail_plugins {
+	acl = yes
+}
+
 protocol imap {
-	mail_plugins = $mail_plugins imap_acl
+	mail_plugins {
+		imap_acl = yes
+	}
 }
-plugin {
-  acl = vfile
-}
+
+acl_driver = vfile
 `
 	if err := os.WriteFile(cfgFilename, []byte(cfg), 0666); err != nil {
 		t.Fatalf("failed to write Dovecot config: %v", err)


### PR DESCRIPTION
In alpine/latest dovecot was updated to version 2.4. The configuration file
syntax changes[^1] made the dovecot.conf, used by tests, invalid.

- The configuration file is adapted to the new syntax.
- The mailbox separator used in TestACL is changed to "/". "." Dovecot is
  configured to use "." as namespace separator. It's not clear why it worked
  before, maybe Dovecot was more lenient.

- TestACL now terminates immediately when the SetACL or GetACL commands fail
  instead of continuing the test.

Adapt the configuration file to the 2.4 syntax.

[^1]: https://doc.dovecot.org/main/installation/upgrade/2.3-to-2.4.html
