### PR TITLE
extra space between lists of multiparts in bodystructure breaks outlook in ios

### DIFF
--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -650,10 +650,7 @@ func writeBodyTypeMpart(enc *imapwire.Encoder, bs *imap.BodyStructureMultiPart, 
 	if len(bs.Children) == 0 {
 		panic("imapserver: imap.BodyStructureMultiPart must have at least one child")
 	}
-	for i, child := range bs.Children {
-		if i > 0 {
-			enc.SP()
-		}
+	for _, child := range bs.Children {
 		writeBodyStructure(enc, child, extended)
 	}
 


### PR DESCRIPTION
Following Dovecot behavior with no space.