### PR TITLE
imapclient: Add a convenience function to enable whatever go-imap supports

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -154,16 +154,17 @@ type Client struct {
 	decCh  chan struct{}
 	decErr error
 
-	mutex        sync.Mutex
-	state        imap.ConnState
-	caps         imap.CapSet
-	enabled      imap.CapSet
-	pendingCapCh chan struct{}
-	mailbox      *SelectedMailbox
-	cmdTag       uint64
-	pendingCmds  []command
-	contReqs     []continuationRequest
-	closed       bool
+	mutex           sync.Mutex
+	state           imap.ConnState
+	caps            imap.CapSet
+	enabled         imap.CapSet
+	enableAttempted bool
+	pendingCapCh    chan struct{}
+	mailbox         *SelectedMailbox
+	cmdTag          uint64
+	pendingCmds     []command
+	contReqs        []continuationRequest
+	closed          bool
 }
 
 // New creates a new IMAP client.
@@ -530,6 +531,7 @@ func (c *Client) completeCommand(cmd command, err error) {
 			c.state = imap.ConnStateNotAuthenticated
 			c.mailbox = nil
 			c.enabled = make(imap.CapSet)
+			c.enableAttempted = false
 			c.mutex.Unlock()
 		}
 	case *SelectCommand:

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -438,7 +438,7 @@ func (c *Client) beginCommand(name string, cmd command) *commandEncoder {
 	}
 
 	c.pendingCmds = append(c.pendingCmds, cmd)
-	quotedUTF8 := c.caps.Has(imap.CapIMAP4rev2) || c.enabled.Has(imap.CapUTF8Accept)
+	quotedUTF8 := c.enabled.Has(imap.CapIMAP4rev2) || c.enabled.Has(imap.CapUTF8Accept)
 	literalMinus := c.caps.Has(imap.CapLiteralMinus)
 	literalPlus := c.caps.Has(imap.CapLiteralPlus)
 
@@ -533,6 +533,7 @@ func (c *Client) completeCommand(cmd command, err error) {
 			c.enabled = make(imap.CapSet)
 			c.enableAttempted = false
 			c.mutex.Unlock()
+			c.dec.QuotedUTF8 = false
 		}
 	case *SelectCommand:
 		if err == nil {

--- a/imapclient/enable.go
+++ b/imapclient/enable.go
@@ -74,7 +74,12 @@ func (c *Client) handleEnabled() error {
 	for name := range caps {
 		c.enabled[name] = struct{}{}
 	}
+	quotedUTF8 := c.enabled.Has(imap.CapIMAP4rev2) || c.enabled.Has(imap.CapUTF8Accept)
 	c.mutex.Unlock()
+
+	if quotedUTF8 {
+		c.dec.QuotedUTF8 = true
+	}
 
 	if cmd := findPendingCmdByType[*EnableCommand](c); cmd != nil {
 		cmd.data.Caps = caps

--- a/imapclient/enable.go
+++ b/imapclient/enable.go
@@ -6,12 +6,43 @@ import (
 	"github.com/emersion/go-imap/v2"
 )
 
+// maybeAutoEnable is the auto-call described on Enable: on the first
+// Select, if the server supports ENABLE and the caller hasn't run
+// Enable themselves, enable whatever go-imap-supported extensions the
+// server advertises.
+func (c *Client) maybeAutoEnable() {
+	c.mutex.Lock()
+	if c.enableAttempted {
+		c.mutex.Unlock()
+		return
+	}
+	c.mutex.Unlock()
+
+	caps := c.Caps()
+	if !caps.Has(imap.CapIMAP4rev2) && !caps.Has(imap.CapEnable) {
+		return
+	}
+
+	c.Enable(imap.CapIMAP4rev2, imap.CapUTF8Accept, imap.CapMetadata, imap.CapMetadataServer)
+}
+
 // Enable sends an ENABLE command.
 //
 // This command requires support for IMAP4rev2 or the ENABLE extension.
+//
+// If the caller never invokes Enable explicitly, Select will call it
+// on first use with the full set of extensions go-imap supports
+// (intersected with what the server advertises), so that callers who
+// trust go-imap's defaults get sensible behaviour without ceremony.
+// Calling Enable yourself (even with no arguments) suppresses that
+// auto-call.
 func (c *Client) Enable(caps ...imap.Cap) *EnableCommand {
+	c.mutex.Lock()
+	c.enableAttempted = true
+	c.mutex.Unlock()
+
 	// Enabling an extension may change the IMAP syntax, so only allow the
-	// extensions we support here
+	// extensions we'll be able to parse.
 	for _, name := range caps {
 		switch name {
 		case imap.CapIMAP4rev2, imap.CapUTF8Accept, imap.CapMetadata, imap.CapMetadataServer:

--- a/imapclient/envelope_roundtrip_test.go
+++ b/imapclient/envelope_roundtrip_test.go
@@ -1,0 +1,76 @@
+package imapclient_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestFetchEnvelopeUTF8RoundTrip appends a message with UTF-8 in From/To
+// headers, then FETCHes ENVELOPE under UTF8=ACCEPT and checks the
+// address fields come back intact. This exercises the server side
+// (ExtractEnvelope + writeEnvelope) and the client side (readEnvelope)
+// across the wire in UTF-8 mode (RFC 9755 §3).
+func TestFetchEnvelopeUTF8RoundTrip(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateAuthenticated)
+	defer client.Close()
+	defer server.Close()
+
+	if !client.Caps().Has(imap.CapUTF8Accept) {
+		t.Skipf("missing UTF8=ACCEPT support")
+	}
+	if _, err := client.Enable(imap.CapUTF8Accept).Wait(); err != nil {
+		t.Fatalf("Enable(CapUTF8Accept) = %v", err)
+	}
+
+	const rawMessage = "MIME-Version: 1.0\r\n" +
+		"Message-Id: <utf8-roundtrip@grå.org>\r\n" +
+		"From: Grå <grå@grå.org>\r\n" +
+		"To: 阿Q <阿Q@例子.中国>, Gøril <gøril@example.com>\r\n" +
+		"Subject: hilsen frå Grå\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: 8bit\r\n" +
+		"\r\n" +
+		"hei\r\n"
+
+	appendCmd := client.Append("INBOX", int64(len(rawMessage)), nil)
+	appendCmd.Write([]byte(rawMessage))
+	appendCmd.Close()
+	if _, err := appendCmd.Wait(); err != nil {
+		t.Fatalf("Append.Wait() = %v", err)
+	}
+
+	if _, err := client.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select.Wait() = %v", err)
+	}
+
+	// newClientServerPair appends a simple ASCII message first, so ours
+	// is sequence number 2.
+	messages, err := client.Fetch(imap.SeqSetNum(2), &imap.FetchOptions{Envelope: true}).Collect()
+	if err != nil {
+		t.Fatalf("Fetch = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("len(messages) = %v, want 1", len(messages))
+	}
+	env := messages[0].Envelope
+	if env == nil {
+		t.Fatalf("Envelope is nil")
+	}
+
+	wantFrom := []imap.Address{{Name: "Grå", Mailbox: "grå", Host: "grå.org"}}
+	wantTo := []imap.Address{
+		{Name: "阿Q", Mailbox: "阿Q", Host: "例子.中国"},
+		{Name: "Gøril", Mailbox: "gøril", Host: "example.com"},
+	}
+	if !reflect.DeepEqual(env.From, wantFrom) {
+		t.Errorf("From = %#v, want %#v", env.From, wantFrom)
+	}
+	if !reflect.DeepEqual(env.To, wantTo) {
+		t.Errorf("To = %#v, want %#v", env.To, wantTo)
+	}
+	if env.Subject != "hilsen frå Grå" {
+		t.Errorf("Subject = %q, want %q", env.Subject, "hilsen frå Grå")
+	}
+}

--- a/imapclient/envelope_test.go
+++ b/imapclient/envelope_test.go
@@ -1,0 +1,73 @@
+package imapclient
+
+import (
+	"bufio"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadEnvelopeUTF8Addresses feeds readEnvelope hand-crafted ENVELOPE
+// wire forms with UTF-8 in addr-mailbox and addr-host and checks that the
+// bytes survive unmangled.
+//
+// readAddress reads each field via ExpectNString, which just consumes a
+// quoted string / literal / NIL — so any byte sequence the server
+// emits after UTF8=ACCEPT should round-trip. The cases below cover UTF-8 in
+// the local part only, in the host only, in both halves, and a raw
+// (non-encoded-word) UTF-8 display name.
+func TestReadEnvelopeUTF8Addresses(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		envWire string
+		want    []imap.Address
+	}{
+		{
+			name:    "utf8 in local part only",
+			envWire: `(("阿Q" NIL "阿Q" "例子.中国"))`,
+			want:    []imap.Address{{Name: "阿Q", Mailbox: "阿Q", Host: "例子.中国"}},
+		},
+		{
+			name:    "utf8 in host only",
+			envWire: `(("Arnt" NIL "arnt" "grå.org"))`,
+			want:    []imap.Address{{Name: "Arnt", Mailbox: "arnt", Host: "grå.org"}},
+		},
+		{
+			name:    "utf8 in both halves",
+			envWire: `(("Grå" NIL "grå" "grå.org"))`,
+			want:    []imap.Address{{Name: "Grå", Mailbox: "grå", Host: "grå.org"}},
+		},
+		{
+			name:    "encoded-word display name",
+			envWire: `(("=?utf-8?b?R8O4cmls?=" NIL "gøril" "example.com"))`,
+			want:    []imap.Address{{Name: "Gøril", Mailbox: "gøril", Host: "example.com"}},
+		},
+		{
+			name: "multiple addresses",
+			envWire: `(("阿Q" NIL "阿Q" "例子.中国")` +
+				`("Gøril" NIL "gøril" "example.com"))`,
+			want: []imap.Address{
+				{Name: "阿Q", Mailbox: "阿Q", Host: "例子.中国"},
+				{Name: "Gøril", Mailbox: "gøril", Host: "example.com"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wrap the From field in a complete ENVELOPE: the other
+			// address slots and string fields are NIL.
+			wire := `(NIL NIL ` + tc.envWire + ` NIL NIL NIL NIL NIL NIL NIL)`
+			dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(wire)), imapwire.ConnSideClient)
+
+			env, err := readEnvelope(dec, &Options{})
+			if err != nil {
+				t.Fatalf("readEnvelope: %v", err)
+			}
+			if !reflect.DeepEqual(env.From, tc.want) {
+				t.Errorf("From = %#v, want %#v", env.From, tc.want)
+			}
+		})
+	}
+}

--- a/imapclient/select.go
+++ b/imapclient/select.go
@@ -7,12 +7,17 @@ import (
 
 // Select sends a SELECT or EXAMINE command.
 //
+// If you haven't sent an ENABLE command, this will first enable
+// the recommended set of extensions.
+//
 // A nil options pointer is equivalent to a zero options value.
 func (c *Client) Select(mailbox string, options *imap.SelectOptions) *SelectCommand {
 	cmdName := "SELECT"
 	if options != nil && options.ReadOnly {
 		cmdName = "EXAMINE"
 	}
+
+	c.maybeAutoEnable()
 
 	cmd := &SelectCommand{mailbox: mailbox}
 	enc := c.beginCommand(cmdName, cmd)

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -178,6 +178,9 @@ func (c *Conn) serve() {
 		dec := imapwire.NewDecoder(c.br, imapwire.ConnSideServer)
 		dec.MaxSize = maxCommandSize
 		dec.CheckBufferedLiteralFunc = c.checkBufferedLiteral
+		c.mutex.Lock()
+		dec.QuotedUTF8 = c.enabled.Has(imap.CapIMAP4rev2) || c.enabled.Has(imap.CapUTF8Accept)
+		c.mutex.Unlock()
 
 		if c.state == imap.ConnStateLogout || dec.EOF() {
 			break

--- a/imapserver/list.go
+++ b/imapserver/list.go
@@ -206,6 +206,9 @@ func readListMailbox(dec *imapwire.Decoder) (string, error) {
 			return "", dec.Err()
 		}
 	}
+	if dec.QuotedUTF8 {
+		return mailbox, nil
+	}
 	return utf7.Decode(mailbox)
 }
 

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -55,6 +55,10 @@ type Decoder struct {
 	// MaxSize defines a maximum number of bytes to be read from the input.
 	// Literals are ignored.
 	MaxSize int64
+	// QuotedUTF8 means the peer sends mailbox names as raw UTF-8 rather than
+	// modified UTF-7 (RFC 3501 §5.1.3). Set this once IMAP4rev2 or
+	// UTF8=ACCEPT has been enabled.
+	QuotedUTF8 bool
 
 	r         *bufio.Reader
 	side      ConnSide
@@ -515,6 +519,10 @@ func (dec *Decoder) ExpectMailbox(ptr *string) bool {
 	}
 	if strings.EqualFold(name, "INBOX") {
 		*ptr = "INBOX"
+		return true
+	}
+	if dec.QuotedUTF8 {
+		*ptr = name
 		return true
 	}
 	name, err := utf7.Decode(name)

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -152,14 +152,11 @@ func (enc *Encoder) stringLiteral(s string) {
 func (enc *Encoder) Mailbox(name string) *Encoder {
 	if strings.EqualFold(name, "INBOX") {
 		return enc.Atom("INBOX")
-	} else {
-		if enc.QuotedUTF8 {
-			name = utf7.Escape(name)
-		} else {
-			name = utf7.Encode(name)
-		}
-		return enc.String(name)
 	}
+	if !enc.QuotedUTF8 {
+		name = utf7.Encode(name)
+	}
+	return enc.String(name)
 }
 
 func (enc *Encoder) NumSet(numSet imap.NumSet) *Encoder {

--- a/internal/imapwire/mailbox_test.go
+++ b/internal/imapwire/mailbox_test.go
@@ -1,0 +1,54 @@
+package imapwire
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestMailboxEncodeDecodeAmpersandDash covers the mailbox name "A&-B" in
+// both modified-UTF-7 and raw-UTF-8 modes.
+//
+// In modified UTF-7 (the default), the literal '&' has to be sent as
+// "&-", so "A&-B" is wire form "A&--B". In UTF-8 mode (after ENABLE
+// IMAP4rev2 or ENABLE UTF8=ACCEPT, RFC 9755), '&' has no special meaning
+// and "A&-B" is sent verbatim.
+func TestMailboxEncodeDecodeAmpersandDash(t *testing.T) {
+	const name = "A&-B"
+
+	for _, tc := range []struct {
+		mode     string
+		quoted   bool
+		wireBody string // bytes between the surrounding quotes
+	}{
+		{"modified UTF-7", false, "A&--B"},
+		{"UTF-8 (RFC 9755)", true, "A&-B"},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			var buf bytes.Buffer
+			bw := bufio.NewWriter(&buf)
+			enc := NewEncoder(bw, ConnSideClient)
+			enc.QuotedUTF8 = tc.quoted
+			enc.Mailbox(name)
+			if err := bw.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+			got := buf.String()
+			want := `"` + tc.wireBody + `"`
+			if got != want {
+				t.Errorf("encode: got %q, want %q", got, want)
+			}
+
+			dec := NewDecoder(bufio.NewReader(strings.NewReader(got)), ConnSideServer)
+			dec.QuotedUTF8 = tc.quoted
+			var roundtrip string
+			if !dec.ExpectMailbox(&roundtrip) {
+				t.Fatalf("decode failed: %v", dec.Err())
+			}
+			if roundtrip != name {
+				t.Errorf("decode: got %q, want %q", roundtrip, name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows a client to trust go-imap's judgment and not clutter its source with IMAP details.