### PR TITLE
imapclient: fix missing pointer dereference in list example

### DIFF
--- a/imapclient/example_test.go
+++ b/imapclient/example_test.go
@@ -120,7 +120,7 @@ func ExampleClient_List_stream() {
 		if mbox == nil {
 			break
 		}
-		log.Printf("Mailbox %q contains %v messages (%v unseen)", mbox.Mailbox, mbox.Status.NumMessages, mbox.Status.NumUnseen)
+		log.Printf("Mailbox %q contains %v messages (%v unseen)", mbox.Mailbox, *mbox.Status.NumMessages, *mbox.Status.NumUnseen)
 	}
 	if err := listCmd.Close(); err != nil {
 		log.Fatalf("LIST command failed: %v", err)


### PR DESCRIPTION
There is a small bug in the list example.

Output of the example was:
```
Connecting to server...
Connected
Logged in
Mailbox "INBOX" contains 0xc00043c058 messages (0xc00043c070 unseen)
```

after this change:
```
Connecting to server...
Connected
Logged in
Mailbox "INBOX" contains 369 messages (154 unseen)
```

Fixes #737 