### PR TITLE
imapclient: handle unsolicited LIST responses in UnilateralDataHandler

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -1205,6 +1205,12 @@ type UnilateralDataHandler struct {
 	// Requires ENABLE METADATA or ENABLE SERVER-METADATA.
 	Metadata func(mailbox string, entries []string)
 
+	// Called when the server sends an unsolicited LIST response.
+	//
+	// Used with NOTIFY MailboxName events (RFC 5465) to detect mailbox
+	// creation, deletion, or renaming, and for subscription changes.
+	List func(data *imap.ListData)
+
 	// Called when the server sends an unsolicited STATUS response.
 	//
 	// Commonly used with NOTIFY to receive mailbox status updates

--- a/imapclient/list.go
+++ b/imapclient/list.go
@@ -119,6 +119,12 @@ func (c *Client) handleList() error {
 		cmd.data.List = data
 	}
 
+	if cmd == nil {
+		if handler := c.options.unilateralDataHandler().List; handler != nil {
+			handler(data)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When subscribing to MailboxName or SubscriptionChange via the NOTIFY extension, the server may send unsolicited LIST responses. Handle these via UnilateralDataHandler.

All other responses which can be triggered via NOTIFY are already properly handled.