### PR TITLE
imapclient: wrap inner errors

### DIFF
--- a/imapclient/acl.go
+++ b/imapclient/acl.go
@@ -64,7 +64,7 @@ func (cmd *GetACLCommand) Wait() (*GetACLData, error) {
 func (c *Client) handleMyRights() error {
 	data, err := readMyRights(c.dec)
 	if err != nil {
-		return fmt.Errorf("in myrights-response: %v", err)
+		return fmt.Errorf("in myrights-response: %w", err)
 	}
 	if cmd := findPendingCmdByType[*MyRightsCommand](c); cmd != nil {
 		cmd.data = *data
@@ -75,7 +75,7 @@ func (c *Client) handleMyRights() error {
 func (c *Client) handleGetACL() error {
 	data, err := readGetACL(c.dec)
 	if err != nil {
-		return fmt.Errorf("in getacl-response: %v", err)
+		return fmt.Errorf("in getacl-response: %w", err)
 	}
 	if cmd := findPendingCmdByType[*GetACLCommand](c); cmd != nil {
 		cmd.data = *data

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -631,20 +631,20 @@ func (c *Client) readResponse() error {
 
 	if c.dec.Special('+') {
 		if err := c.readContinueReq(); err != nil {
-			return fmt.Errorf("in continue-req: %v", err)
+			return fmt.Errorf("in continue-req: %w", err)
 		}
 		return nil
 	}
 
 	var tag, typ string
 	if !c.dec.Expect(c.dec.Special('*') || c.dec.Atom(&tag), "'*' or atom") {
-		return fmt.Errorf("in response: cannot read tag: %v", c.dec.Err())
+		return fmt.Errorf("in response: cannot read tag: %w", c.dec.Err())
 	}
 	if !c.dec.ExpectSP() {
-		return fmt.Errorf("in response: %v", c.dec.Err())
+		return fmt.Errorf("in response: %w", c.dec.Err())
 	}
 	if !c.dec.ExpectAtom(&typ) {
-		return fmt.Errorf("in response: cannot read type: %v", c.dec.Err())
+		return fmt.Errorf("in response: cannot read type: %w", c.dec.Err())
 	}
 
 	// Change typ to uppercase, as it's case-insensitive
@@ -663,11 +663,11 @@ func (c *Client) readResponse() error {
 		err = c.readResponseData(typ)
 	}
 	if err != nil {
-		return fmt.Errorf("in %v: %v", token, err)
+		return fmt.Errorf("in %v: %w", token, err)
 	}
 
 	if !c.dec.ExpectCRLF() {
-		return fmt.Errorf("in response: %v", c.dec.Err())
+		return fmt.Errorf("in response: %w", c.dec.Err())
 	}
 
 	if startTLS != nil {
@@ -723,14 +723,14 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 	var code string
 	if hasSP && c.dec.Special('[') { // resp-text-code
 		if !c.dec.ExpectAtom(&code) {
-			return nil, fmt.Errorf("in resp-text-code: %v", c.dec.Err())
+			return nil, fmt.Errorf("in resp-text-code: %w", c.dec.Err())
 		}
 		// TODO: LONGENTRIES and MAXSIZE from METADATA
 		switch code {
 		case "CAPABILITY": // capability-data
 			caps, err := readCapabilities(c.dec)
 			if err != nil {
-				return nil, fmt.Errorf("in capability-data: %v", err)
+				return nil, fmt.Errorf("in capability-data: %w", err)
 			}
 			c.setCaps(caps)
 		case "APPENDUID":
@@ -739,7 +739,7 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 				uid         imap.UID
 			)
 			if !c.dec.ExpectSP() || !c.dec.ExpectNumber(&uidValidity) || !c.dec.ExpectSP() || !c.dec.ExpectUID(&uid) {
-				return nil, fmt.Errorf("in resp-code-apnd: %v", c.dec.Err())
+				return nil, fmt.Errorf("in resp-code-apnd: %w", c.dec.Err())
 			}
 			if cmd, ok := cmd.(*AppendCommand); ok {
 				cmd.data.UID = uid
@@ -751,7 +751,7 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 			}
 			uidValidity, srcUIDs, dstUIDs, err := readRespCodeCopyUID(c.dec)
 			if err != nil {
-				return nil, fmt.Errorf("in resp-code-copy: %v", err)
+				return nil, fmt.Errorf("in resp-code-copy: %w", err)
 			}
 			switch cmd := cmd.(type) {
 			case *CopyCommand:
@@ -771,13 +771,13 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 			}
 		}
 		if !c.dec.ExpectSpecial(']') {
-			return nil, fmt.Errorf("in resp-text: %v", c.dec.Err())
+			return nil, fmt.Errorf("in resp-text: %w", c.dec.Err())
 		}
 		hasSP = c.dec.SP()
 	}
 	var text string
 	if hasSP && !c.dec.ExpectText(&text) {
-		return nil, fmt.Errorf("in resp-text: %v", c.dec.Err())
+		return nil, fmt.Errorf("in resp-text: %w", c.dec.Err())
 	}
 
 	var cmdErr error
@@ -836,13 +836,13 @@ func (c *Client) readResponseData(typ string) error {
 		var code string
 		if hasSP && c.dec.Special('[') { // resp-text-code
 			if !c.dec.ExpectAtom(&code) {
-				return fmt.Errorf("in resp-text-code: %v", c.dec.Err())
+				return fmt.Errorf("in resp-text-code: %w", c.dec.Err())
 			}
 			switch code {
 			case "CAPABILITY": // capability-data
 				caps, err := readCapabilities(c.dec)
 				if err != nil {
-					return fmt.Errorf("in capability-data: %v", err)
+					return fmt.Errorf("in capability-data: %w", err)
 				}
 				c.setCaps(caps)
 			case "PERMANENTFLAGS":
@@ -888,7 +888,7 @@ func (c *Client) readResponseData(typ string) error {
 				}
 				uidValidity, srcUIDs, dstUIDs, err := readRespCodeCopyUID(c.dec)
 				if err != nil {
-					return fmt.Errorf("in resp-code-copy: %v", err)
+					return fmt.Errorf("in resp-code-copy: %w", err)
 				}
 				if cmd := findPendingCmdByType[*MoveCommand](c); cmd != nil {
 					cmd.data.UIDValidity = uidValidity
@@ -915,14 +915,14 @@ func (c *Client) readResponseData(typ string) error {
 				}
 			}
 			if !c.dec.ExpectSpecial(']') {
-				return fmt.Errorf("in resp-text: %v", c.dec.Err())
+				return fmt.Errorf("in resp-text: %w", c.dec.Err())
 			}
 			hasSP = c.dec.SP()
 		}
 
 		var text string
 		if hasSP && !c.dec.ExpectText(&text) {
-			return fmt.Errorf("in resp-text: %v", c.dec.Err())
+			return fmt.Errorf("in resp-text: %w", c.dec.Err())
 		}
 
 		if code == "CLOSED" {
@@ -1033,7 +1033,7 @@ func (c *Client) WaitGreeting() error {
 		return c.greetingErr
 	case <-c.decCh:
 		if c.decErr != nil {
-			return fmt.Errorf("got error before greeting: %v", c.decErr)
+			return fmt.Errorf("got error before greeting: %w", c.decErr)
 		}
 		return fmt.Errorf("connection closed before greeting")
 	}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -673,7 +673,7 @@ func (c *Client) handleFetch(seqNum uint32) error {
 
 			envelope, err := readEnvelope(dec, &c.options)
 			if err != nil {
-				return fmt.Errorf("in envelope: %v", err)
+				return fmt.Errorf("in envelope: %w", err)
 			}
 
 			item = FetchItemDataEnvelope{Envelope: envelope}
@@ -709,7 +709,7 @@ func (c *Client) handleFetch(seqNum uint32) error {
 					var err error
 					section, err = readSectionSpec(dec)
 					if err != nil {
-						return fmt.Errorf("in section-spec: %v", err)
+						return fmt.Errorf("in section-spec: %w", err)
 					}
 				case "BINARY":
 					part, dot := readSectionPart(dec)
@@ -857,7 +857,7 @@ func readEnvelope(dec *imapwire.Decoder, options *Options) (*imap.Envelope, erro
 	for _, addrList := range addrLists {
 		l, err := readAddressList(dec, options)
 		if err != nil {
-			return nil, fmt.Errorf("in %v: %v", addrList.name, err)
+			return nil, fmt.Errorf("in %v: %w", addrList.name, err)
 		} else if !dec.ExpectSP() {
 			return nil, dec.Err()
 		}
@@ -903,7 +903,7 @@ func readAddress(dec *imapwire.Decoder, options *Options) (*imap.Address, error)
 		dec.ExpectNString(&addr.Mailbox) && dec.ExpectSP() &&
 		dec.ExpectNString(&addr.Host) && dec.ExpectSpecial(')')
 	if !ok {
-		return nil, fmt.Errorf("in address: %v", dec.Err())
+		return nil, fmt.Errorf("in address: %w", dec.Err())
 	}
 	// TODO: handle error
 	addr.Name, _ = options.decodeText(name)
@@ -941,7 +941,7 @@ func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, erro
 		bs, err = readBodyTypeMpart(dec, options)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("in %v: %v", token, err)
+		return nil, fmt.Errorf("in %v: %w", token, err)
 	}
 
 	for dec.SP() {
@@ -1030,7 +1030,7 @@ func readBodyType1part(dec *imapwire.Decoder, typ string, options *Options) (*im
 	if hasSP {
 		bs.Extended, err = readBodyExt1part(dec, options)
 		if err != nil {
-			return nil, fmt.Errorf("in body-ext-1part: %v", err)
+			return nil, fmt.Errorf("in body-ext-1part: %w", err)
 		}
 	}
 
@@ -1052,7 +1052,7 @@ func readBodyExt1part(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 	var err error
 	ext.Disposition, err = readBodyFldDsp(dec, options)
 	if err != nil {
-		return nil, fmt.Errorf("in body-fld-dsp: %v", err)
+		return nil, fmt.Errorf("in body-fld-dsp: %w", err)
 	}
 
 	if !dec.SP() {
@@ -1061,7 +1061,7 @@ func readBodyExt1part(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 
 	ext.Language, err = readBodyFldLang(dec)
 	if err != nil {
-		return nil, fmt.Errorf("in body-fld-lang: %v", err)
+		return nil, fmt.Errorf("in body-fld-lang: %w", err)
 	}
 
 	if !dec.SP() {
@@ -1094,7 +1094,7 @@ func readBodyTypeMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStruc
 		var err error
 		bs.Extended, err = readBodyExtMpart(dec, options)
 		if err != nil {
-			return nil, fmt.Errorf("in body-ext-mpart: %v", err)
+			return nil, fmt.Errorf("in body-ext-mpart: %w", err)
 		}
 	}
 
@@ -1107,7 +1107,7 @@ func readBodyExtMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 	var err error
 	ext.Params, err = readBodyFldParam(dec, options)
 	if err != nil {
-		return nil, fmt.Errorf("in body-fld-param: %v", err)
+		return nil, fmt.Errorf("in body-fld-param: %w", err)
 	}
 
 	if !dec.SP() {
@@ -1116,7 +1116,7 @@ func readBodyExtMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 
 	ext.Disposition, err = readBodyFldDsp(dec, options)
 	if err != nil {
-		return nil, fmt.Errorf("in body-fld-dsp: %v", err)
+		return nil, fmt.Errorf("in body-fld-dsp: %w", err)
 	}
 
 	if !dec.SP() {
@@ -1125,7 +1125,7 @@ func readBodyExtMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 
 	ext.Language, err = readBodyFldLang(dec)
 	if err != nil {
-		return nil, fmt.Errorf("in body-fld-lang: %v", err)
+		return nil, fmt.Errorf("in body-fld-lang: %w", err)
 	}
 
 	if !dec.SP() {

--- a/imapclient/id.go
+++ b/imapclient/id.go
@@ -80,7 +80,7 @@ func addIDKeyValue(enc *commandEncoder, isFirstKey *bool, key, value string) {
 func (c *Client) handleID() error {
 	data, err := c.readID(c.dec)
 	if err != nil {
-		return fmt.Errorf("in id: %v", err)
+		return fmt.Errorf("in id: %w", err)
 	}
 
 	if cmd := findPendingCmdByType[*IDCommand](c); cmd != nil {
@@ -105,7 +105,7 @@ func (c *Client) readID(dec *imapwire.Decoder) (*imap.IDData, error) {
 	err := dec.ExpectList(func() error {
 		var keyOrValue string
 		if !dec.String(&keyOrValue) {
-			return fmt.Errorf("in id key-val list: %v", dec.Err())
+			return fmt.Errorf("in id key-val list: %w", dec.Err())
 		}
 
 		if currKey == "" {

--- a/imapclient/list.go
+++ b/imapclient/list.go
@@ -92,7 +92,7 @@ func (c *Client) List(ref, pattern string, options *imap.ListOptions) *ListComma
 func (c *Client) handleList() error {
 	data, err := readList(c.dec)
 	if err != nil {
-		return fmt.Errorf("in LIST: %v", err)
+		return fmt.Errorf("in LIST: %w", err)
 	}
 
 	cmd := c.findPendingCmdFunc(func(cmd command) bool {
@@ -204,22 +204,22 @@ func readList(dec *imapwire.Decoder) (*imap.ListData, error) {
 			case "CHILDINFO":
 				data.ChildInfo, err = readChildInfoExtendedItem(dec)
 				if err != nil {
-					return fmt.Errorf("in childinfo-extended-item: %v", err)
+					return fmt.Errorf("in childinfo-extended-item: %w", err)
 				}
 			case "OLDNAME":
 				data.OldName, err = readOldNameExtendedItem(dec)
 				if err != nil {
-					return fmt.Errorf("in oldname-extended-item: %v", err)
+					return fmt.Errorf("in oldname-extended-item: %w", err)
 				}
 			default:
 				if !dec.DiscardValue() {
-					return fmt.Errorf("in tagged-ext-val: %v", err)
+					return fmt.Errorf("in tagged-ext-val: %w", err)
 				}
 			}
 			return nil
 		})
 		if err != nil {
-			return nil, fmt.Errorf("in mbox-list-extended: %v", err)
+			return nil, fmt.Errorf("in mbox-list-extended: %w", err)
 		}
 	}
 

--- a/imapclient/metadata.go
+++ b/imapclient/metadata.go
@@ -105,7 +105,7 @@ func (c *Client) SetMetadata(mailbox string, entries map[string]*[]byte) *Comman
 func (c *Client) handleMetadata() error {
 	data, err := readMetadataResp(c.dec)
 	if err != nil {
-		return fmt.Errorf("in metadata-resp: %v", err)
+		return fmt.Errorf("in metadata-resp: %w", err)
 	}
 
 	cmd := c.findPendingCmdFunc(func(anyCmd command) bool {

--- a/imapclient/namespace.go
+++ b/imapclient/namespace.go
@@ -19,7 +19,7 @@ func (c *Client) Namespace() *NamespaceCommand {
 func (c *Client) handleNamespace() error {
 	data, err := readNamespaceResponse(c.dec)
 	if err != nil {
-		return fmt.Errorf("in namespace-response: %v", err)
+		return fmt.Errorf("in namespace-response: %w", err)
 	}
 	if cmd := findPendingCmdByType[*NamespaceCommand](c); cmd != nil {
 		cmd.data = *data
@@ -74,7 +74,7 @@ func readNamespace(dec *imapwire.Decoder) ([]imap.NamespaceDescriptor, error) {
 	err := dec.ExpectNList(func() error {
 		descr, err := readNamespaceDescr(dec)
 		if err != nil {
-			return fmt.Errorf("in namespace-descr: %v", err)
+			return fmt.Errorf("in namespace-descr: %w", err)
 		}
 		l = append(l, *descr)
 		return nil

--- a/imapclient/quota.go
+++ b/imapclient/quota.go
@@ -53,7 +53,7 @@ func (c *Client) SetQuota(root string, limits map[imap.QuotaResourceType]int64) 
 func (c *Client) handleQuota() error {
 	data, err := readQuotaResponse(c.dec)
 	if err != nil {
-		return fmt.Errorf("in quota-response: %v", err)
+		return fmt.Errorf("in quota-response: %w", err)
 	}
 
 	cmd := c.findPendingCmdFunc(func(cmd command) bool {
@@ -83,7 +83,7 @@ func (c *Client) handleQuota() error {
 func (c *Client) handleQuotaRoot() error {
 	mailbox, roots, err := readQuotaRoot(c.dec)
 	if err != nil {
-		return fmt.Errorf("in quotaroot-response: %v", err)
+		return fmt.Errorf("in quotaroot-response: %w", err)
 	}
 
 	cmd := c.findPendingCmdFunc(func(anyCmd command) bool {
@@ -153,7 +153,7 @@ func readQuotaResponse(dec *imapwire.Decoder) (*QuotaData, error) {
 			resData QuotaResourceData
 		)
 		if !dec.ExpectAtom(&name) || !dec.ExpectSP() || !dec.ExpectNumber64(&resData.Usage) || !dec.ExpectSP() || !dec.ExpectNumber64(&resData.Limit) {
-			return fmt.Errorf("in quota-resource: %v", dec.Err())
+			return fmt.Errorf("in quota-resource: %w", dec.Err())
 		}
 		data.Resources[imap.QuotaResourceType(name)] = resData
 		return nil

--- a/imapclient/status.go
+++ b/imapclient/status.go
@@ -55,7 +55,7 @@ func (c *Client) Status(mailbox string, options *imap.StatusOptions) *StatusComm
 func (c *Client) handleStatus() error {
 	data, err := readStatus(c.dec)
 	if err != nil {
-		return fmt.Errorf("in status: %v", err)
+		return fmt.Errorf("in status: %w", err)
 	}
 
 	cmd := c.findPendingCmdFunc(func(cmd command) bool {
@@ -107,7 +107,7 @@ func readStatus(dec *imapwire.Decoder) (*imap.StatusData, error) {
 
 	err := dec.ExpectList(func() error {
 		if err := readStatusAttVal(dec, &data); err != nil {
-			return fmt.Errorf("in status-att-val: %v", dec.Err())
+			return fmt.Errorf("in status-att-val: %w", dec.Err())
 		}
 		return nil
 	})

--- a/imapclient/thread.go
+++ b/imapclient/thread.go
@@ -41,7 +41,7 @@ func (c *Client) handleThread() error {
 	for c.dec.SP() {
 		data, err := readThreadList(c.dec)
 		if err != nil {
-			return fmt.Errorf("in thread-list: %v", err)
+			return fmt.Errorf("in thread-list: %w", err)
 		}
 		if cmd != nil {
 			cmd.data = append(cmd.data, *data)


### PR DESCRIPTION
The following error (split here into multiple lines for readability):

    in response: cannot read tag:
    read tcp 192.168.2.3:51198->185.97.174.199:993:
    read: connection reset by peer

Does not match the following condition:

    errors.Is(err, syscall.ECONNRESET)

Calls to fmt.Errorf use `%v`, which embeds the inner error's string representation, without wrapping the inner error.

Use `%w` instead, to wrap the inner error, enabling usages such as the example above.