### PR TITLE
imapclient: gracefully handle dynamic UID sets in COPYUID response

### DIFF
--- a/imapclient/copy.go
+++ b/imapclient/copy.go
@@ -1,8 +1,6 @@
 package imapclient
 
 import (
-	"fmt"
-
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/internal/imapwire"
 )
@@ -31,7 +29,11 @@ func readRespCodeCopyUID(dec *imapwire.Decoder) (uidValidity uint32, srcUIDs, ds
 		return 0, nil, nil, dec.Err()
 	}
 	if srcUIDs.Dynamic() || dstUIDs.Dynamic() {
-		return 0, nil, nil, fmt.Errorf("imapclient: server returned dynamic number set in COPYUID response")
+		// Some servers (e.g. Purelymail) return wildcard "*" in
+		// COPYUID UID sets, violating RFC 4315. Treat this as if
+		// the server didn't send COPYUID at all rather than
+		// tearing down the connection.
+		return 0, nil, nil, nil
 	}
 	return uidValidity, srcUIDs, dstUIDs, nil
 }


### PR DESCRIPTION
Fixes #749

## Problem

When a server returns a COPYUID response code containing `*` (e.g. `OK [COPYUID 1234567890 1:5 100:*]`), `readRespCodeCopyUID` returns an error. Since this parsing happens in the background read goroutine, the error propagates up through `readResponse()` → `read()`, which sets `decErr`, calls `closeWithError`, fails all pending commands, and tears down the TCP connection.

The copy/move operation itself succeeded on the server — only the response metadata is malformed.

## Fix

When `srcUIDs.Dynamic()` or `dstUIDs.Dynamic()` is true, return zero values with no error instead of a fatal error. This treats the malformed COPYUID as if the server did not send COPYUID at all, which matches the behavior when a server does not support UIDPLUS.

The connection stays alive and all other pending commands continue normally.

## Testing

All existing tests pass. This is a one-line behavioral change in error handling.