### PR TITLE
imapclient: don't tear down the connection on dynamic COPYUID

### DIFF
--- a/imapclient/copy.go
+++ b/imapclient/copy.go
@@ -1,8 +1,6 @@
 package imapclient
 
 import (
-	"fmt"
-
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/internal/imapwire"
 )
@@ -31,7 +29,14 @@ func readRespCodeCopyUID(dec *imapwire.Decoder) (uidValidity uint32, srcUIDs, ds
 		return 0, nil, nil, dec.Err()
 	}
 	if srcUIDs.Dynamic() || dstUIDs.Dynamic() {
-		return 0, nil, nil, fmt.Errorf("imapclient: server returned dynamic number set in COPYUID response")
+		// RFC 4315 forbids "*" in COPYUID UID sets, but some servers
+		// (Purelymail observed in #749) send it anyway after MOVE. The
+		// COPY/MOVE itself already succeeded on the server side; only
+		// the response metadata is malformed. Treat it the same as a
+		// server that doesn't support UIDPLUS at all — return empty UID
+		// mapping and no error — so the read loop doesn't tear down the
+		// whole connection over an advisory field.
+		return 0, nil, nil, nil
 	}
 	return uidValidity, srcUIDs, dstUIDs, nil
 }


### PR DESCRIPTION
Closes #749.

\`readRespCodeCopyUID\` returns an error when the server's COPYUID set contains \`*\`. RFC 4315 forbids that, but some real servers (Purelymail per the issue) send it anyway after MOVE. The error then bubbles up through the background read loop, sets \`decErr\`, calls \`closeWithError\`, and tears down the connection — so a single malformed advisory field fails every pending command on the connection and forces a reconnect, even though the MOVE itself already succeeded on the server.

Match the no-UIDPLUS path instead: when the response is dynamic, drop the UID mapping (zero \`uidValidity\`, nil source/dest sets) and return no error. The caller sees what it would see from a server that doesn't support UIDPLUS at all — empty \`CopyData.SourceUIDs\` / \`DestUIDs\` — and the connection stays up.

Tested locally with \`go test ./imapclient/...\`, all green.