### PR TITLE
Remove redundant setReadTimeout

### DIFF
--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -183,7 +183,6 @@ func (c *Conn) serve() {
 			break
 		}
 
-		c.setReadTimeout(cmdReadTimeout)
 		if err := c.readCommand(dec); err != nil {
 			if !errors.Is(err, net.ErrClosed) {
 				c.server.logger().Printf("failed to read command: %v", err)


### PR DESCRIPTION
We set read timeout in 176 line. Removed setter rewrite our timeout