### PR TITLE
imapclient: add X-GM-LABELS (X-GM-EXT-1) FETCH support

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -19,6 +19,7 @@ type FetchOptions struct {
 	BinarySection     []*FetchItemBinarySection     // requires IMAP4rev2 or BINARY
 	BinarySectionSize []*FetchItemBinarySectionSize // requires IMAP4rev2 or BINARY
 	ModSeq            bool                          // requires CONDSTORE
+	GmailLabels       bool                          // requires the X-GM-EXT-1 extension (Gmail)
 
 	ChangedSince uint64 // requires CONDSTORE
 }

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -57,6 +57,7 @@ func writeFetchItems(enc *imapwire.Encoder, numKind imapwire.NumKind, options *i
 		"INTERNALDATE":  options.InternalDate,
 		"RFC822.SIZE":   options.RFC822Size,
 		"MODSEQ":        options.ModSeq,
+		"X-GM-LABELS":   options.GmailLabels,
 	}
 	for k, req := range m {
 		if req {
@@ -356,6 +357,7 @@ var (
 	_ FetchItemData = FetchItemDataRFC822Size{}
 	_ FetchItemData = FetchItemDataUID{}
 	_ FetchItemData = FetchItemDataBodyStructure{}
+	_ FetchItemData = FetchItemDataGmailLabels{}
 )
 
 type discarder interface {
@@ -479,6 +481,18 @@ type FetchItemDataModSeq struct {
 
 func (FetchItemDataModSeq) fetchItemData() {}
 
+// FetchItemDataGmailLabels holds data returned by FETCH X-GM-LABELS.
+//
+// This requires the X-GM-EXT-1 extension advertised by Gmail. Each entry is a
+// Gmail label: system labels are returned with a leading backslash (e.g.
+// "\\Inbox", "\\Sent", "\\Important", "\\Starred"), user labels are returned
+// verbatim (decoded from modified UTF-7 when non-ASCII).
+type FetchItemDataGmailLabels struct {
+	Labels []string
+}
+
+func (FetchItemDataGmailLabels) fetchItemData() {}
+
 // FetchBodySectionBuffer is a buffer for the data returned by
 // FetchItemBodySection.
 type FetchBodySectionBuffer struct {
@@ -507,7 +521,8 @@ type FetchMessageBuffer struct {
 	BodySection       []FetchBodySectionBuffer
 	BinarySection     []FetchBinarySectionBuffer
 	BinarySectionSize []FetchItemDataBinarySectionSize
-	ModSeq            uint64 // requires CONDSTORE
+	ModSeq            uint64   // requires CONDSTORE
+	GmailLabels       []string // requires the X-GM-EXT-1 extension (Gmail)
 }
 
 func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
@@ -554,6 +569,8 @@ func (buf *FetchMessageBuffer) populateItemData(item FetchItemData) error {
 		buf.BinarySectionSize = append(buf.BinarySectionSize, item)
 	case FetchItemDataModSeq:
 		buf.ModSeq = item.ModSeq
+	case FetchItemDataGmailLabels:
+		buf.GmailLabels = item.Labels
 	default:
 		panic(fmt.Errorf("unsupported fetch item data %T", item))
 	}
@@ -801,6 +818,15 @@ func (c *Client) handleFetch(seqNum uint32) error {
 				return dec.Err()
 			}
 			item = FetchItemDataModSeq{ModSeq: modSeq}
+		case "X-GM-LABELS":
+			if !dec.ExpectSP() {
+				return dec.Err()
+			}
+			labels, err := readGmailLabels(dec)
+			if err != nil {
+				return fmt.Errorf("in x-gm-labels: %v", err)
+			}
+			item = FetchItemDataGmailLabels{Labels: labels}
 		default:
 			return fmt.Errorf("unsupported msg-att name: %q", attName)
 		}
@@ -826,6 +852,44 @@ func (c *Client) handleFetch(seqNum uint32) error {
 
 func isMsgAttNameChar(ch byte) bool {
 	return ch != '[' && imapwire.IsAtomChar(ch)
+}
+
+// readGmailLabels parses the parenthesised label list returned by the Gmail
+// X-GM-EXT-1 "X-GM-LABELS" FETCH data item, e.g.
+//
+//	(\Inbox \Sent "Travel" "Receipts/2024")
+//
+// System labels are flag-like (a backslash followed by an atom) and are
+// returned with their leading backslash preserved. User labels are astrings
+// (quoted strings or atoms) and are returned verbatim. An empty list "()" is
+// valid (a message with no labels) and yields a nil slice.
+func readGmailLabels(dec *imapwire.Decoder) ([]string, error) {
+	var labels []string
+	err := dec.ExpectList(func() error {
+		// Tolerate a stray leading space inside the list, mirroring the
+		// flag-list leniency in internal.ExpectFlagList.
+		dec.SP()
+
+		if dec.Special('\\') {
+			// System label: a backslash followed by an atom (\Inbox, \Sent,
+			// \Important, \Starred, \Trash, \Spam, \Draft, ...).
+			var name string
+			if !dec.ExpectAtom(&name) {
+				return dec.Err()
+			}
+			labels = append(labels, "\\"+name)
+			return nil
+		}
+		// User label: an astring (atom or quoted string; may contain spaces
+		// when quoted, and is modified-UTF-7 encoded when non-ASCII).
+		var label string
+		if !dec.ExpectAString(&label) {
+			return dec.Err()
+		}
+		labels = append(labels, label)
+		return nil
+	})
+	return labels, err
 }
 
 func readEnvelope(dec *imapwire.Decoder, options *Options) (*imap.Envelope, error) {

--- a/imapclient/fetch_gmail_test.go
+++ b/imapclient/fetch_gmail_test.go
@@ -1,0 +1,117 @@
+package imapclient_test
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// TestFetchGmailLabels exercises the X-GM-EXT-1 "X-GM-LABELS" FETCH data item
+// against a scripted raw IMAP server (the in-process imapmemserver does not
+// implement the Gmail extension). It verifies the client both emits the
+// "X-GM-LABELS" fetch item and parses the parenthesised label list, mixing
+// backslash-prefixed system labels with quoted user labels (one containing a
+// space and a slash).
+func TestFetchGmailLabels(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	defer ln.Close()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("Accept() = %v", err)
+			return
+		}
+		defer conn.Close()
+		r := bufio.NewReader(conn)
+
+		writeLine := func(s string) {
+			if _, err := conn.Write([]byte(s + "\r\n")); err != nil {
+				t.Errorf("server write: %v", err)
+			}
+		}
+
+		// Greeting advertising the Gmail extension.
+		writeLine("* OK [CAPABILITY IMAP4rev2 X-GM-EXT-1] ready")
+
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			fields := strings.SplitN(line, " ", 2)
+			tag := fields[0]
+			rest := ""
+			if len(fields) > 1 {
+				rest = strings.ToUpper(fields[1])
+			}
+			switch {
+			case strings.HasPrefix(rest, "LOGIN"):
+				writeLine(tag + " OK LOGIN completed")
+			case strings.HasPrefix(rest, "SELECT"):
+				writeLine("* 1 EXISTS")
+				writeLine("* OK [UIDVALIDITY 1] .")
+				writeLine("* OK [UIDNEXT 43] .")
+				writeLine(tag + " OK [READ-WRITE] SELECT completed")
+			case strings.HasPrefix(rest, "FETCH"), strings.HasPrefix(rest, "UID FETCH"):
+				// Return a message with a mix of system and user labels.
+				writeLine(`* 1 FETCH (UID 42 X-GM-LABELS (\Inbox \Sent "Travel" "Receipts/2024"))`)
+				writeLine(tag + " OK FETCH completed")
+			case strings.HasPrefix(rest, "LOGOUT"):
+				writeLine("* BYE logging out")
+				writeLine(tag + " OK LOGOUT completed")
+				return
+			default:
+				writeLine(tag + " OK done")
+			}
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("net.Dial() = %v", err)
+	}
+	client := imapclient.New(conn, nil)
+	defer client.Close()
+
+	if err := client.Login(testUsername, testPassword).Wait(); err != nil {
+		t.Fatalf("Login().Wait() = %v", err)
+	}
+	if _, err := client.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select().Wait() = %v", err)
+	}
+
+	msgs, err := client.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		UID:         true,
+		GmailLabels: true,
+	}).Collect()
+	if err != nil {
+		t.Fatalf("Fetch().Collect() = %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs) = %d, want 1", len(msgs))
+	}
+	got := msgs[0].GmailLabels
+	want := []string{`\Inbox`, `\Sent`, "Travel", "Receipts/2024"}
+	if len(got) != len(want) {
+		t.Fatalf("GmailLabels = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("GmailLabels[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if msgs[0].UID != 42 {
+		t.Errorf("UID = %d, want 42", msgs[0].UID)
+	}
+}


### PR DESCRIPTION
# Upstream PR: add X-GM-LABELS (X-GM-EXT-1) FETCH support to imapclient

**Target:** `github.com/emersion/go-imap` (v2 / `imapclient`)
**Patch:** `go-imap-xgmlabels-upstream.patch` (git am-able; generated from the
original `github.com/emersion/go-imap/v2` module path, before the herold fork
rename).

## Title

imapclient: add X-GM-LABELS (X-GM-EXT-1) FETCH support

## Description

Gmail's IMAP server advertises the `X-GM-EXT-1` capability and exposes each
message's set of labels through the `X-GM-LABELS` FETCH data item
(<https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels>).
Today the client cannot fetch it: `handleFetch` reaches its `default:` branch and
returns `unsupported msg-att name: "X-GM-LABELS"`, which aborts the whole FETCH
response — so the item is unusable even via the unilateral/raw paths.

This change adds first-class, opt-in support, mirroring how `MODSEQ` (another
extension-gated item) is wired:

- **Request:** `imap.FetchOptions.GmailLabels bool` (documented "requires the
  X-GM-EXT-1 extension"). `writeFetchItems` emits the `X-GM-LABELS` atom when set.
- **Parse:** a `case "X-GM-LABELS":` in `handleFetch` reads the parenthesised
  label list. System labels are flag-shaped (a backslash followed by an atom,
  e.g. `\Inbox`, `\Sent`, `\Important`, `\Starred`, `\Trash`, `\Spam`, `\Draft`)
  and are preserved with their leading backslash; user labels are astrings
  (quoted or atom, modified-UTF-7 when non-ASCII) and are returned verbatim. An
  empty list `()` is valid. Result is exposed as `FetchItemDataGmailLabels{Labels
  []string}`.
- **Collect:** `FetchMessageBuffer.GmailLabels []string`, populated by
  `populateItemData`.

The item is only emitted when the caller opts in via `FetchOptions.GmailLabels`,
so non-Gmail servers are unaffected. The server side is untouched.

## Tests

`imapclient/fetch_gmail_test.go` drives the client against a scripted raw IMAP
server (the in-tree `imapmemserver` does not implement the Gmail extension) and
asserts a round-trip over a mixed label set: two system labels plus two quoted
user labels, one containing a space and one containing a slash. `go test ./...`
and `go vet ./...` pass (the pre-existing unkeyed-struct-literal vet notices in
`imapserver` are unrelated to this change).

## Notes

- Scope is intentionally limited to `X-GM-LABELS`, the load-bearing item.
  `X-GM-MSGID` / `X-GM-THRID` could be added the same way if desired, but are
  left out to keep the surface minimal.
- Wire format reference: RFC 3501 fetch syntax plus Gmail's extension doc; the
  label-list reader tolerates a stray leading space inside the list, matching the
  existing leniency in `internal.ExpectFlagList`.
