### PR TITLE
imapclient: send an empty SASL continuation as an empty line

### DIFF
--- a/imapclient/authenticate.go
+++ b/imapclient/authenticate.go
@@ -1,6 +1,7 @@
 package imapclient
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/emersion/go-sasl"
@@ -76,7 +77,12 @@ type authenticateCommand struct {
 }
 
 func (c *Client) writeSASLResp(resp []byte) error {
-	respStr := internal.EncodeSASL(resp)
+	// A continuation response is base64 (RFC 3501). A zero-length response must be
+	// an empty line: the "=" zero-length marker (RFC 4959) is valid only in the
+	// AUTHENTICATE initial-response slot, not in a continuation, where strict
+	// servers (e.g. Dovecot) reject "=" as invalid base64. This matters for
+	// multi-step mechanisms like GSSAPI, whose mutual-auth step sends an empty token.
+	respStr := base64.StdEncoding.EncodeToString(resp)
 	if _, err := c.bw.WriteString(respStr + "\r\n"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #760.

`imapclient.writeSASLResp` encodes a zero-length continuation response as `=` (via `internal.EncodeSASL`). `=` is the RFC 4959 zero-length *initial-response* marker, valid only in the `AUTHENTICATE <mech> =` command line, not in a continuation, where it is not valid base64. Strict servers such as Dovecot reject it (`Invalid base64 data in continued response`).

This surfaces with multi-step mechanisms whose client emits a zero-length continuation token — e.g. SASL GSSAPI (RFC 4752), whose mutual-authentication step sends an empty token after the server's AP-REP. Single-round mechanisms (PLAIN, OAUTHBEARER) are unaffected.

The fix base64-encodes the continuation directly, so an empty response becomes an empty line. `EncodeSASL` (with the `=` rule) is unchanged and still used for the initial-response slot in `Authenticate`.