### PR TITLE
Handle tagged server response errors in APPEND command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -267,6 +267,16 @@ func (c *Client) execute(cmdr imap.Commander, h responses.Handler) (*imap.Status
 			return nil, err
 		}
 
+		// The server may have replied with a tagged status response (e.g.
+		// NO/BAD) instead of a continuation request for a synchronizing literal.
+		// In that case the handler already captured the real response;
+		// prefer it over the generic write error.
+		select {
+		case result := <-doneHandle:
+			return result.status, result.err
+		default:
+		}
+
 		return nil, err
 	}
 	// Flush writer if we are upgrading

--- a/client/cmd_auth_test.go
+++ b/client/cmd_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -470,8 +471,15 @@ func TestClient_Append_failed(t *testing.T) {
 	tag, _ := s.ScanCmd()
 	s.WriteString(tag + " BAD APPEND failed\r\n")
 
-	if err := <-done; err == nil {
+	err := <-done
+	if err == nil {
 		t.Fatal("c.Append() = nil, want an error from the server")
+	}
+	if strings.Contains(err.Error(), "no continuation request received") {
+		t.Fatalf("c.Append() = %v, want the server's response, not the generic literal error", err)
+	}
+	if !strings.Contains(err.Error(), "APPEND failed") {
+		t.Fatalf("c.Append() = %v, want an error carrying the server's response", err)
 	}
 
 	// Try a second time, the server accepts


### PR DESCRIPTION
In `APPEND` the server may send an error message instead of a continuation request. Currently this error message is swallowed and a generic "no continuation request received" is returned, thus masking the real problem.

Triggered by: https://github.com/Necoro/feed2imap-go/issues/193

Analysis and code proposed by Claude,