### PR TITLE
imapclient: support BINARY literal8 for APPEND

### DIFF
--- a/append.go
+++ b/append.go
@@ -8,6 +8,11 @@ import (
 type AppendOptions struct {
 	Flags []Flag
 	Time  time.Time
+
+	// Binary sends the message as a literal8 (RFC 3516) so that arbitrary
+	// binary data such as NUL bytes is preserved. The server must advertise
+	// the BINARY capability or support IMAP4rev2.
+	Binary bool
 }
 
 // AppendData is the data returned by an APPEND command.

--- a/imapclient/append.go
+++ b/imapclient/append.go
@@ -24,9 +24,12 @@ func (c *Client) Append(mailbox string, size int64, options *imap.AppendOptions)
 	if options != nil && !options.Time.IsZero() {
 		cmd.enc.String(options.Time.Format(internal.DateTimeLayout)).SP()
 	}
-	// TODO: literal8 for BINARY
 	// TODO: UTF8 data ext for UTF8=ACCEPT, with literal8
-	cmd.wc = cmd.enc.Literal(size)
+	if options != nil && options.Binary {
+		cmd.wc = cmd.enc.Literal8(size)
+	} else {
+		cmd.wc = cmd.enc.Literal(size)
+	}
 	return cmd
 }
 

--- a/imapclient/append_test.go
+++ b/imapclient/append_test.go
@@ -1,6 +1,7 @@
 package imapclient_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -25,4 +26,47 @@ func TestAppend(t *testing.T) {
 	}
 
 	// TODO: fetch back message and check body
+}
+
+func TestAppendBinary(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateAuthenticated)
+	defer client.Close()
+	defer server.Close()
+
+	// A body with a NUL byte can only be transmitted safely as a literal8.
+	body := []byte("Subject: bin\r\n\r\nbefore\x00after")
+
+	appendCmd := client.Append("INBOX", int64(len(body)), &imap.AppendOptions{Binary: true})
+	if _, err := appendCmd.Write(body); err != nil {
+		t.Fatalf("AppendCommand.Write() = %v", err)
+	}
+	if err := appendCmd.Close(); err != nil {
+		t.Fatalf("AppendCommand.Close() = %v", err)
+	}
+	if _, err := appendCmd.Wait(); err != nil {
+		t.Fatalf("AppendCommand.Wait() = %v", err)
+	}
+
+	// The setup appends one message before this one, so ours is the second.
+	if _, err := client.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select().Wait() = %v", err)
+	}
+	bodySection := &imap.FetchItemBodySection{}
+	fetchOptions := &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{bodySection},
+	}
+	messages, err := client.Fetch(imap.SeqSetNum(2), fetchOptions).Collect()
+	if err != nil {
+		t.Fatalf("Fetch() = %v", err)
+	} else if len(messages) != 1 {
+		t.Fatalf("len(messages) = %v, want 1", len(messages))
+	}
+
+	b := messages[0].FindBodySection(bodySection)
+	if b == nil {
+		t.Fatalf("FindBodySection() = nil")
+	}
+	if !bytes.Equal(b, body) {
+		t.Errorf("body mismatch: got %q, want %q", b, body)
+	}
 }

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -1145,6 +1145,15 @@ func (ce *commandEncoder) flush() {
 
 // Literal encodes a literal.
 func (ce *commandEncoder) Literal(size int64) io.WriteCloser {
+	return ce.literal(size, false)
+}
+
+// Literal8 encodes a literal8 (RFC 3516).
+func (ce *commandEncoder) Literal8(size int64) io.WriteCloser {
+	return ce.literal(size, true)
+}
+
+func (ce *commandEncoder) literal(size int64, binary bool) io.WriteCloser {
 	var contReq *imapwire.ContinuationRequest
 	ce.client.mutex.Lock()
 	hasCapLiteralMinus := ce.client.caps.Has(imap.CapLiteralMinus)
@@ -1153,8 +1162,14 @@ func (ce *commandEncoder) Literal(size int64) io.WriteCloser {
 		contReq = ce.client.registerContReq(ce.cmd)
 	}
 	ce.client.setWriteTimeout(literalWriteTimeout)
+	var wc io.WriteCloser
+	if binary {
+		wc = ce.Encoder.Literal8(size, contReq)
+	} else {
+		wc = ce.Encoder.Literal(size, contReq)
+	}
 	return literalWriter{
-		WriteCloser: ce.Encoder.Literal(size, contReq),
+		WriteCloser: wc,
 		client:      ce.client,
 	}
 }

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -257,11 +257,26 @@ func (enc *Encoder) UID(uid imap.UID) *Encoder {
 // nil to be sent to the channel before writing the literal data. If an error
 // is sent to the channel, the literal will be cancelled.
 func (enc *Encoder) Literal(size int64, sync *ContinuationRequest) io.WriteCloser {
+	return enc.writeLiteral(size, false, sync)
+}
+
+// Literal8 writes a literal8 (RFC 3516): a literal prefixed with "~" that may
+// carry arbitrary binary data. It is only valid where the grammar allows it,
+// e.g. as APPEND data when the server advertises the BINARY capability.
+//
+// The semantics are otherwise identical to Literal.
+func (enc *Encoder) Literal8(size int64, sync *ContinuationRequest) io.WriteCloser {
+	return enc.writeLiteral(size, true, sync)
+}
+
+func (enc *Encoder) writeLiteral(size int64, binary bool, sync *ContinuationRequest) io.WriteCloser {
 	if sync != nil && enc.side == ConnSideServer {
 		panic("imapwire: sync must be nil on a server-side Encoder.Literal")
 	}
 
-	// TODO: literal8
+	if binary {
+		enc.writeString("~")
+	}
 	enc.writeString("{")
 	enc.Number64(size)
 	if sync == nil && enc.side == ConnSideClient {

--- a/internal/imapwire/encoder_test.go
+++ b/internal/imapwire/encoder_test.go
@@ -1,0 +1,32 @@
+package imapwire
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestEncoderLiteral8(t *testing.T) {
+	var buf bytes.Buffer
+	bw := bufio.NewWriter(&buf)
+	enc := NewEncoder(bw, ConnSideClient)
+
+	data := []byte("he\x00llo")
+	wc := enc.Literal8(int64(len(data)), nil)
+	if _, err := wc.Write(data); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatalf("Close() = %v", err)
+	}
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("Flush() = %v", err)
+	}
+
+	// Non-synchronizing literal8 on the client side: "~{n+}\r\n" followed by
+	// the raw bytes.
+	want := append([]byte("~{6+}\r\n"), data...)
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("Literal8() wrote %q, want %q", buf.Bytes(), want)
+	}
+}


### PR DESCRIPTION
APPEND always wrote a regular literal, so a message with a NUL or other 8-bit byte in it could not be sent reliably. This adds an `AppendOptions.Binary` flag that makes the client send the payload as a literal8 (`~{...}`, RFC 3516) instead of a plain literal.

The server side already skips the `~` prefix before reading the APPEND literal, so with this change the round trip works whenever the server advertises `BINARY` or supports IMAP4rev2; the default (`Binary: false`) is unchanged. I wired `Literal8` through the wire encoder and the client command encoder alongside the existing `Literal`, which also clears the `// TODO: literal8` notes that were sitting in both spots.

Added an encoder unit test for the `~{...}` output and a client round-trip test that appends a body containing a NUL byte and fetches it back to confirm the bytes are preserved.

Closes #670