### PR TITLE
imapserver: answer BAD for a parse failure, not NO [SERVERBUG]

### DIFF
--- a/imapserver/parse_error_wire_test.go
+++ b/imapserver/parse_error_wire_test.go
@@ -1,0 +1,128 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// parseWire is a raw connection to a server: these cases are about the exact
+// status line, which a client library hides.
+type parseWire struct {
+	t    *testing.T
+	conn net.Conn
+	rd   *bufio.Reader
+}
+
+func dialParseServer(t *testing.T, newSession func(imapserver.Session) imapserver.Session) *parseWire {
+	t.Helper()
+	mem := imapmemserver.New()
+	u := imapmemserver.NewUser("u", "p")
+	if err := u.Create("INBOX", nil); err != nil {
+		t.Fatal(err)
+	}
+	mem.AddUser(u)
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			s := imapserver.Session(mem.NewSession())
+			if newSession != nil {
+				s = newSession(s)
+			}
+			return s, nil, nil
+		},
+		InsecureAuth: true,
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: struct{}{}},
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go srv.Serve(ln) //nolint:errcheck
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	w := &parseWire{t: t, conn: c, rd: bufio.NewReader(c)}
+	w.line()
+	fmt.Fprint(w.conn, "a1 LOGIN u p\r\n")
+	w.until("a1")
+	return w
+}
+
+func (w *parseWire) line() string {
+	w.t.Helper()
+	_ = w.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	l, err := w.rd.ReadString('\n')
+	if err != nil {
+		w.t.Fatalf("read: %v", err)
+	}
+	return strings.TrimRight(l, "\r\n")
+}
+
+// until returns the tagged status line for tag.
+func (w *parseWire) until(tag string) string {
+	w.t.Helper()
+	for {
+		l := w.line()
+		if strings.HasPrefix(l, tag+" ") {
+			return l
+		}
+	}
+}
+
+// A command the grammar refuses is answered BAD, not NO [SERVERBUG]: a parse
+// failure arriving as a plain error tells the client the server is broken.
+func TestMalformedCommandIsBad(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  string
+	}{
+		{"sequence-set", `a2 SEARCH HEADER Subject fileinto test`},
+		{"mailbox name", `a2 SELECT "&"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := dialParseServer(t, nil)
+			fmt.Fprint(w.conn, tc.cmd+"\r\n")
+			got := w.until("a2")
+			if strings.Contains(got, "SERVERBUG") {
+				t.Errorf("malformed command answered %q; want BAD", got)
+			}
+			if !strings.HasPrefix(got, "a2 BAD") {
+				t.Errorf("answer was %q; want BAD", got)
+			}
+		})
+	}
+}
+
+// failingSelect answers a well-formed SELECT with a plain error, which is what a
+// server fault looks like to the connection loop.
+type failingSelect struct {
+	imapserver.Session
+}
+
+func (s *failingSelect) Select(string, *imap.SelectOptions) (*imap.SelectData, error) {
+	return nil, errors.New("boom")
+}
+
+// A plain error from the handler is still NO [SERVERBUG]: this classifies parse
+// failures, it does not answer BAD to everything.
+func TestHandlerErrorIsServerBug(t *testing.T) {
+	w := dialParseServer(t, func(s imapserver.Session) imapserver.Session {
+		return &failingSelect{Session: s}
+	})
+	fmt.Fprint(w.conn, "a2 SELECT INBOX\r\n")
+	if got := w.until("a2"); !strings.Contains(got, "SERVERBUG") {
+		t.Errorf("handler error answered %q; want NO [SERVERBUG]", got)
+	}
+}

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -331,7 +331,11 @@ func readSearchKeyWithAtom(criteria *imap.SearchCriteria, dec *imapwire.Decoder,
 	default:
 		seqSet, err := imapwire.ParseSeqSet(key)
 		if err != nil {
-			return err
+			// An unknown key reaches here as a sequence-set candidate; failing
+			// to parse it is the client's syntax, not a server fault.
+			return &imapwire.DecoderExpectError{
+				Message: fmt.Sprintf("invalid search-key %q", key),
+			}
 		}
 		criteria.SeqNum = append(criteria.SeqNum, seqSet)
 	}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -518,10 +518,15 @@ func (dec *Decoder) ExpectMailbox(ptr *string) bool {
 		return true
 	}
 	name, err := utf7.Decode(name)
-	if err == nil {
-		*ptr = name
+	if err != nil {
+		// A name that is not modified UTF-7 is a malformed command: the loop
+		// answers BAD for an expect error, NO [SERVERBUG] for anything else.
+		return dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("invalid mailbox name: %v", err),
+		})
 	}
-	return dec.returnErr(err)
+	*ptr = name
+	return true
 }
 
 func (dec *Decoder) ExpectUID(ptr *imap.UID) bool {
@@ -545,7 +550,10 @@ func (dec *Decoder) ExpectNumSet(kind NumKind, ptr *imap.NumSet) bool {
 	}
 	numSet, err := imapnum.ParseSet(s)
 	if err != nil {
-		return dec.returnErr(err)
+		// Same: the client sent what the grammar does not allow.
+		return dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("invalid sequence-set: %v", err),
+		})
 	}
 
 	switch kind {


### PR DESCRIPTION
A malformed command is answered `NO [SERVERBUG] Internal server error` rather
than `BAD`:

```
a1 SEARCH HEADER Subject "fileinto test"   -> OK
a1 SEARCH HEADER Subject fileinto test     -> NO [SERVERBUG] Internal server error
```

The second is the client's syntax: an unquoted argument containing a space, so
`test` is read as the next search key. The server logs
`handling SEARCH command: in search-key: imap: bad number set value "TEST"`.

The connection loop already tells the two cases apart by error type — a
`*imapwire.DecoderExpectError` becomes `BAD [CLIENTBUG]` with the syntax text,
anything else is logged and answered `NO [SERVERBUG]`. Three places returned a
plain error from a failed parse and so fell into the second branch:

- `Decoder.ExpectNumSet`, where `imapnum.ParseSet` refuses the sequence-set;
- `Decoder.ExpectMailbox`, where the name is not modified UTF-7;
- `readSearchKeyWithAtom`'s default branch, which parses an unknown search key
  as a sequence-set candidate — the one clients actually hit.

Each returns a `DecoderExpectError` carrying the same message now.

Left alone deliberately: the literal reader's copy failure. A client that
disappears mid-literal is a connection error rather than a syntax one, and
classifying it as either without deciding the right answer seemed wrong — happy
to follow up if you have a preference.

Tests are over a real connection because the exact status line is the point: a
malformed sequence-set and a malformed mailbox name are BAD, and a handler that
returns a plain error is still `NO [SERVERBUG]`, so this stays a classification
rather than "answer BAD to everything".
