### PR TITLE
imapserver: avoid int64 overflow in extractPartial

### DIFF
--- a/imapserver/message.go
+++ b/imapserver/message.go
@@ -149,14 +149,15 @@ func extractPartial(b []byte, partial *imap.SectionPartial) []byte {
 		return b
 	}
 
-	end := partial.Offset + partial.Size
 	if partial.Offset > int64(len(b)) {
 		return nil
 	}
-	if end > int64(len(b)) {
-		end = int64(len(b))
+	// Offset+Size can overflow int64, so clamp the remaining length instead.
+	size := int64(len(b)) - partial.Offset
+	if partial.Size >= 0 && partial.Size < size {
+		size = partial.Size
 	}
-	return b[partial.Offset:end]
+	return b[partial.Offset : partial.Offset+size]
 }
 
 func ExtractBinarySection(r io.Reader, item *imap.FetchItemBinarySection) []byte {

--- a/imapserver/partial_test.go
+++ b/imapserver/partial_test.go
@@ -1,0 +1,27 @@
+package imapserver
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+func TestExtractPartialOverflow(t *testing.T) {
+	b := []byte("hello world")
+	for _, tc := range []struct {
+		name    string
+		partial imap.SectionPartial
+		want    string
+	}{
+		{"overflow", imap.SectionPartial{Offset: 5, Size: 1<<63 - 1}, " world"},
+		{"negative-size", imap.SectionPartial{Offset: 5, Size: -1}, " world"},
+		{"normal", imap.SectionPartial{Offset: 2, Size: 3}, "llo"},
+		{"clamped", imap.SectionPartial{Offset: 6, Size: 100}, "world"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(extractPartial(b, &tc.partial)); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`extractPartial` (`imapserver/message.go:152`) computes the end offset before its bounds checks:

```go
end := partial.Offset + partial.Size
if partial.Offset > int64(len(b)) {
	return nil
}
if end > int64(len(b)) {
	end = int64(len(b))
}
return b[partial.Offset:end]
```

Both fields are decoded with `ExpectNumber64` (`imapserver/fetch.go:314`), which is `strconv.ParseInt(s, 10, 64)`, so `Size` can be up to `9223372036854775807`. The sum then wraps negative, and neither guard catches it: `Offset > len(b)` is false, and `end > len(b)` is false *because* `end` is negative. The slice expression panics.

RFC 9051 gives `partial = "<" number64 "." nz-number64 ">"` with `number64` a 63-bit unsigned integer, so this is ABNF-legal input. Against the in-repo `imapmemserver` over TCP, one authenticated client sending

```
d FETCH 1 BODY[]<5.9223372036854775807>
```

gets:

```
panic handling command: runtime error: slice bounds out of range [:-9223372036854775804]
	imapserver.extractPartial(...) imapserver/message.go:159
	imapserver.ExtractBodySection(...) imapserver/message.go:83
	imapmemserver.(*message).fetch(...) imapserver/imapmemserver/message.go:48
```

`ExtractBodySection` and `ExtractBinarySection` are both exported and documented as usable by server backends, so it is reachable directly as well:

```go
imapserver.ExtractBodySection(strings.NewReader(msg),
	&imap.FetchItemBodySection{Partial: &imap.SectionPartial{Offset: 5, Size: 1<<63 - 1}})
```

**Blast radius, stated plainly:** `imapserver/conn.go:95` recovers per connection, logs `panic handling command` and closes the socket. So this is one authenticated client killing its own connection and writing a stack trace to the server log -- not a process crash, and not reachable pre-auth. I would rather scope it that way than call it something it isn't. There is no `SECURITY.md` in the repo, so I am sending it as a normal PR.

## Your own `Merge` already guards this

`internal/imapnum/numset.go:52`:

```go
// s is "n" or "n:m", if m == ^uint32(0) then t is "n:*"
if s.Stop+1 >= t.Start || s.Stop == ^uint32(0) {
```

The wrap at the type maximum was already recognised there and guarded explicitly. `extractPartial` does the same addition on two decoder-supplied `int64`s without it -- and its two bounds checks were plainly written to make an out-of-range slice impossible, so this is a hole in an existing guard rather than a missing one.

## The fix

Derive the length from `len(b)` instead of adding the two inputs, so the upper bound cannot overflow:

```go
size := int64(len(b)) - partial.Offset
if partial.Size >= 0 && partial.Size < size {
	size = partial.Size
}
return b[partial.Offset : partial.Offset+size]
```

## Behaviour change

None for any input the old code handled -- the `normal` and `clamped` rows in the new test pass on both sides. Only the previously-panicking inputs change, and they now return the clamped tail. **No existing test row changes**; `Partial` had zero occurrences in any `_test.go`.

## Verification

CI as `.build.yml` runs it: `test -z $(gofmt -l .)` clean, `go test -race ./...` -- `imapclient`, `imapserver`, `internal/imapnum`, `internal/utf7` all ok. `go vet ./...` is byte-identical to `v2` apart from four line numbers shifting. **Skipped half:** the `test-dovecot` task needs a live Dovecot; I did not run it.

Two mutations, each anchored to `extractPartial`:

| mutation | result |
|---|---|
| drop `partial.Size >= 0 &&` | fails the `negative-size` row |
| revert to the `Offset+Size` form | fails the `overflow` row |

## What I did not change

- `maybeReadPartial` (`imapserver/fetch.go:314`) still accepts `Size == 0` and an offset above `uint32`. RFC 9051 says `nz-number64` for the count, so rejecting `<n.0>` would be spec-correct, but it turns an answer into a `BAD` and is a separate decision.
- `imapserver/fetch.go:428`, which echoes the offset with `Number(uint32(partial.Offset))` and so truncates what the int64 decoder accepted. Real inconsistency, separate finding, changes response bytes.
- `^uint32(0)` as "no APPENDLIMIT" (`capability.go:184`, `imapclient/status.go:153`). Whether a real limit of 4294967295 should be distinguishable from "unset" is a semantic the repo does not state, so that is issue material rather than a patch.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
