### PR TITLE
imapserver: announce updates queued while not idling

### DIFF
--- a/imapserver/idle_test.go
+++ b/imapserver/idle_test.go
@@ -1,0 +1,163 @@
+package imapserver_test
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+const (
+	idleTestUsername = "shinji"
+	idleTestPassword = "eva01"
+)
+
+// startIdleTestServer runs an in-memory server with a single user and an INBOX.
+func startIdleTestServer(t *testing.T) (host string, port int) {
+	t.Helper()
+
+	user := imapmemserver.NewUser(idleTestUsername, idleTestPassword)
+	if err := user.Create("INBOX", nil); err != nil {
+		t.Fatalf("create INBOX: %v", err)
+	}
+
+	mem := imapmemserver.New()
+	mem.AddUser(user)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+	})
+	t.Cleanup(func() { _ = srv.Close() })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", addr.Port
+}
+
+func dialIdleTestClient(t *testing.T, host string, port int, opts *imapclient.Options) *imapclient.Client {
+	t.Helper()
+
+	c, err := imapclient.DialInsecure(fmt.Sprintf("%s:%d", host, port), opts)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if err := c.Login(idleTestUsername, idleTestPassword).Wait(); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	return c
+}
+
+func appendIdleTestMessage(t *testing.T, host string, port int, subject string) {
+	t.Helper()
+
+	c := dialIdleTestClient(t, host, port, nil)
+	body := strings.Join([]string{
+		"From: misato@example.com",
+		"To: shinji@example.com",
+		"Subject: " + subject,
+		"Date: " + time.Now().Format(time.RFC1123Z),
+		"",
+		"Get in the robot.",
+		"",
+	}, "\r\n")
+
+	cmd := c.Append("INBOX", int64(len(body)), nil)
+	if _, err := cmd.Write([]byte(body)); err != nil {
+		t.Fatalf("write APPEND literal: %v", err)
+	}
+	if err := cmd.Close(); err != nil {
+		t.Fatalf("close APPEND literal: %v", err)
+	}
+	if _, err := cmd.Wait(); err != nil {
+		t.Fatalf("APPEND: %v", err)
+	}
+}
+
+// An update queued while nothing is listening must still be announced by the
+// next IDLE.
+//
+// SessionTracker.queueUpdate always appends to the queue, but only signals a
+// listener that already exists, and t.updates is nil whenever Idle is not
+// running. So a message that arrives while the client is between DONE and its
+// next IDLE is queued and then never announced: Idle's loop only polls when
+// signalled, so it waits for the *next* update to carry the pending one, and on
+// a quiet mailbox that never comes.
+//
+// The same hole is reachable at startup, because handleIdle writes the
+// "+ idling" continuation before starting the goroutine that calls Idle — a
+// client is told it is idling before anything is listening. That form is a race
+// and awkward to test; this one is deterministic and has the same cause.
+func TestIdleAnnouncesUpdatesQueuedWhileNotIdling(t *testing.T) {
+	host, port := startIdleTestServer(t)
+
+	exists := make(chan uint32, 8)
+	c := dialIdleTestClient(t, host, port, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Mailbox: func(data *imapclient.UnilateralDataMailbox) {
+				if data != nil && data.NumMessages != nil {
+					select {
+					case exists <- *data.NumMessages:
+					default:
+					}
+				}
+			},
+		},
+	})
+
+	if _, err := c.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("SELECT: %v", err)
+	}
+
+	// Idle and stop again, the way a client does when it needs the connection
+	// to run a command. The server's tracker now has no listener.
+	idle, err := c.Idle()
+	if err != nil {
+		t.Fatalf("IDLE: %v", err)
+	}
+	if err := idle.Close(); err != nil {
+		t.Fatalf("DONE: %v", err)
+	}
+	drainExists(exists)
+
+	// Delivered by somebody else while this client is not idling.
+	appendIdleTestMessage(t, host, port, "Angel attack")
+
+	idle, err = c.Idle()
+	if err != nil {
+		t.Fatalf("second IDLE: %v", err)
+	}
+	defer idle.Close()
+
+	select {
+	case n := <-exists:
+		if n == 0 {
+			t.Errorf("EXISTS reported %d messages", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the message delivered between DONE and IDLE was never announced")
+	}
+}
+
+func drainExists(ch <-chan uint32) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -212,6 +212,25 @@ func (t *SessionTracker) Idle(w *UpdateWriter, stop <-chan struct{}) error {
 		t.mutex.Unlock()
 	}()
 
+	// Flush updates queued while nothing was listening.
+	//
+	// queueUpdate always appends to the queue, but only signals a listener that
+	// already exists, and t.updates is nil whenever Idle is not running. Two
+	// windows follow from that:
+	//
+	//   - handleIdle writes the "+ idling" continuation before starting the
+	//     goroutine that calls Idle, so the client believes it is idling before
+	//     this registration happens;
+	//   - a client that sends DONE to run a command and then IDLEs again is not
+	//     listening in between.
+	//
+	// An update queued in either window is never announced: the loop below only
+	// polls when signalled, so it waits for the *next* update to carry it, and
+	// on a quiet mailbox that may never arrive.
+	if err := t.Poll(w, true); err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-updates:


### PR DESCRIPTION
`SessionTracker.queueUpdate` always appends to the queue, but only signals a listener that already exists:

```go
t.queue = append(t.queue, *update)
updates = t.updates
t.mutex.Unlock()

if updates != nil {
	select {
	case updates <- struct{}{}:
	default:
	}
}
```

and `t.updates` is nil whenever `Idle` is not running. `Idle`'s loop polls only when signalled, so an update queued while nothing was listening waits for the *next* update to carry it — and on a quiet mailbox that never arrives. The update is silently lost.

Two windows reach it:

1. **Startup.** `handleIdle` writes the `+ idling` continuation before starting the goroutine that calls `session.Idle`, so the client's `Idle()` returns — and the client believes it is idling — before anything is listening:

   ```go
   if err := c.writeContReq("idling"); err != nil {
   	return err
   }
   stop := make(chan struct{})
   done := make(chan error, 1)
   go func() {
   	...
   	done <- c.session.Idle(w, stop)
   }()
   ```

   A delivery in that gap is never announced. This one depends on goroutine scheduling; on a loaded CI machine it cost us roughly one failure in two.

2. **Between DONE and the next IDLE.** A client that stops idling to run a command and then idles again is not listening in between. This one is deterministic, and is what the new test covers.

How we found it: our client files new mail on the IDLE notification, with the fallback poll set to an hour so the test could prove IDLE was what did the filing. About half of CI runs saw the message never filed at all — the watcher idling and silent for the full timeout. Logging every announcement received showed none ever arrived, and the queue above is where it stopped.

## The fix

Poll once after `Idle` registers its channel. The queue is already durable, so nothing else is needed: the pending update is written immediately and the loop then proceeds normally.

Reordering `handleIdle` instead would be worse — starting the goroutine before the continuation lets an EXISTS reach the client before `+ idling`, while the client is still waiting for the continuation.

## Test

`TestIdleAnnouncesUpdatesQueuedWhileNotIdling` uses the DONE/re-IDLE path because it is deterministic and has the same cause. It fails without the fix:

```
--- FAIL: TestIdleAnnouncesUpdatesQueuedWhileNotIdling
    idle_test.go:151: the message delivered between DONE and IDLE was never announced
```

and passes with it (5/5 runs, 0.007s). `go test ./...` is green, `gofmt` clean.

There was no round-trip harness under `imapserver/`, so the test brings a small one (memory server on a random port, a client, and an APPEND from a second connection). Happy to fold it into an existing pattern if you would rather it lived elsewhere.

Reproduced and confirmed present on `v2` HEAD, as well as on the `v2.0.0-beta.7` and `beta.8` tags.